### PR TITLE
Fix Metaculus Cup workflow slug

### DIFF
--- a/.github/workflows/run_bot_on_metaculus_cup.yaml
+++ b/.github/workflows/run_bot_on_metaculus_cup.yaml
@@ -20,7 +20,8 @@ jobs:
       # ---- Required / identity ----
       GIT_SHA: ${{ github.sha }}
       METACULUS_TOKEN: ${{ secrets.METACULUS_TOKEN }}
-      TOURNAMENT_ID: metaculus-cup
+      # Metaculus renamed the Cup slug for Fall 2025; keep this in sync with the live tournament URL.
+      TOURNAMENT_ID: metaculus-cup-fall-2025
       SUBMIT_PREDICTION: "1"
 
       # ---- LLM providers ----

--- a/README.txt
+++ b/README.txt
@@ -97,6 +97,10 @@ run_bot_on_tournament.yaml,
 
 run_bot_on_metaculus_cup.yaml,
 
+> **Note:** Metaculus renames the Cup slug every season. Update the `TOURNAMENT_ID`
+> in `.github/workflows/run_bot_on_metaculus_cup.yaml` to match the current Cup
+> URL (presently `metaculus-cup-fall-2025`).
+
 calibration_refresh.yml (periodic update of calibration weights).
 
 Add secrets (see below), push the repo, and Actions will:


### PR DESCRIPTION
## Summary
- point the Metaculus Cup workflow at the current `metaculus-cup-fall-2025` slug so scheduled runs hit a valid tournament
- document the seasonal slug updates in the README for future maintenance

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68da2a2cfc38832c8c05e63252372194