### PR TITLE
[resolver] A3 — Add Data Dictionary & Governance (link registries)

### DIFF
--- a/resolver/data/README.md
+++ b/resolver/data/README.md
@@ -1,1 +1,12 @@
-# Canonical Registry Notes (A1)
+# Data Registries — Resolver
+
+Authoritative CSVs that standardize **countries** and **hazards** across the resolver.
+
+## Files
+- `countries.csv` — `country_name,iso3`
+- `shocks.csv` — `hazard_code,hazard_label,hazard_class`
+
+## Rules
+- These registries are the **only** allowed values for `iso3`, `hazard_code`, `hazard_label`, `hazard_class`.
+- Update via PRs; keep changes backwards-compatible (additive when possible).
+- Per scope: **earthquakes and other non-forecastable geophysical hazards are excluded** from `shocks.csv`.

--- a/resolver/docs/data_dictionary.md
+++ b/resolver/docs/data_dictionary.md
@@ -1,1 +1,47 @@
-# Resolver Data Dictionary (A3)
+# Data Dictionary — Resolver (A3)
+
+This dictionary defines the **facts** records the resolver stores and reads.  
+All records **must** include both **country_name + iso3** and **hazard_label + hazard_code + hazard_class** (aligned to the registries in `/resolver/data/`).
+
+## Canonical registries (authoritative)
+- `/resolver/data/countries.csv` — columns: `country_name,iso3`
+- `/resolver/data/shocks.csv` — columns: `hazard_code,hazard_label,hazard_class`  
+  (`hazard_class` ∈ `natural | human-induced | epidemic`; **earthquakes excluded** per scope)
+
+## Table: facts (append-only)
+| Field | Type | Req | Description |
+|---|---|:--:|---|
+| event_id | string | R | Stable ID for a country–hazard–episode–revision |
+| country_name | string | R | From countries registry |
+| iso3 | string(3) | R | From countries registry |
+| hazard_code | string | R | From shocks registry |
+| hazard_label | string | R | From shocks registry |
+| hazard_class | string | R | `natural|human-induced|epidemic` (from shocks registry) |
+| metric | enum | R | `in_need` (PIN) \| `affected` \| `displaced` \| `cases` … |
+| value | number | R | Non-negative integer (persons) |
+| unit | enum | R | `persons` \| `persons_cases` (for outbreaks) |
+| as_of_date | date(YYYY-MM-DD) | R | Date figure refers to |
+| publication_date | date | R | Publication date of source |
+| publisher | string | R | OCHA, IFRC, NDMA, UNHCR, IOM-DTM, WHO, etc. |
+| source_type | enum | R | `appeal|sitrep|gov|cluster|agency|media` |
+| source_url | string | R | Canonical URL of doc/portal |
+| doc_title | string | R | Title of doc/page |
+| definition_text | text | R | Verbatim local definition of who is counted |
+| method | enum | R | `api|scrape|manual` |
+| confidence | enum | R | `high|med|low` |
+| revision | int | R | 1…n (newer supersedes older) |
+| artifact_id | string | O | Path/key in object storage |
+| artifact_sha256 | string | O | Hash of saved artifact |
+| notes | text | O | Free-form notes |
+| alt_value | number | O | Kept when conflict rule discards an eligible figure |
+| alt_source_url | string | O | Source of alternative value |
+| proxy_for | enum/null | O | `PIN` when using proxy (e.g., IPC P3+) |
+| precedence_decision | text | O | Brief rationale (e.g., “HNO superset; NDMA older”) |
+| ingested_at | datetime(UTC) | R | Insert timestamp |
+
+**Constraints & validation**
+- `value >= 0`; if `value > national_population(iso3)` ⇒ flag `confidence=low`.
+- `as_of_date <= publication_date <= now`.
+- Uniqueness hint (soft): `(iso3, hazard_code, metric, as_of_date, publisher, revision)`.
+- `metric='in_need'` only when source explicitly publishes **PIN**.
+- For outbreaks where only cases exist, use `metric=cases`, `unit=persons_cases` (do **not** coerce to PIN).

--- a/resolver/docs/governance.md
+++ b/resolver/docs/governance.md
@@ -1,1 +1,49 @@
-# Resolver Governance (A3)
+# Governance & Audit — Resolver (A3)
+
+## Evidence & Traceability
+- Save the original PDF/HTML as an **artifact** (private bucket); store `artifact_id` + `artifact_sha256`.
+- Capture a **verbatim snippet** (±200 chars) around the figure in `definition_text`.
+- Record `method=api|scrape|manual` and `confidence=high|med|low`.
+
+## Versioning & Snapshots
+- **Append-only** facts: new totals are **new rows** with `revision = previous + 1`.
+- **Monthly freeze**: at **23:59 Europe/Istanbul** on the **last day** of each month:  
+  - Write `snapshots/YYYY-MM/facts.parquet` + `manifest.json` (`created_at_utc`, `source_commit_sha`).
+  - **Scoring uses snapshots** for that month; live views use current facts.
+
+## Source Precedence & Conflict
+- Precedence (highest→lowest):  
+  `inter_agency_plan > ifrc_or_gov_sitrep > un_cluster_snapshot > reputable_ingo_un > media_discovery_only`
+- **One total only** — never sum across agencies.
+- **Conflict rule**: if eligible figures differ by **>20%** → choose higher precedence; if same tier, use **newest as_of** then **latest publication**. Keep the alternative in `alt_value` + `alt_source_url` and explain in `precedence_decision`.
+
+## Attribution & Scope
+- A record must **explicitly link** the number to the hazard episode (per policy).  
+- Use country totals; sub-national figures only if they roll up (or are the official national total).
+
+## Quality Controls
+- Schema checks for required fields.
+- Range checks on `value`.
+- Date sanity (as_of ≤ publication ≤ now).
+- Registry checks: `iso3` and `hazard_code` **must** exist in the CSV registries.
+- Outliers (e.g., `value` > national population) → flag `confidence=low` and route to review.
+
+## Roles & Access
+- **Ingestion bot**: append facts + upload artifacts.  
+- **Analyst**: review/override low-confidence records (add a note).  
+- **Resolver**: read-only; returns single number + citation.  
+- **Public dashboard**: read filtered; no artifacts, no PII.
+
+## Licensing & Compliance
+- Only official/publicly accessible documents.  
+- Store `publisher` and any license/terms when available.  
+- Respect robots.txt for scrapes.
+
+## Retention
+- Facts: indefinite (trend analysis).  
+- Artifacts: ≥24 months; cold-store after 12 months.
+
+## Monitoring
+- Source freshness dashboard (last success per source).  
+- Ingestion counts by source/day; error rate; % low-confidence.  
+- Alert on missing freezes and on conflict spikes.


### PR DESCRIPTION
## Summary
- replace the resolver data dictionary with the A3 specification tied to the countries and shocks registries
- update governance guidance to document evidence, versioning, precedence, and access controls for resolver facts
- refresh the resolver data registry README to describe the authoritative CSVs and their usage rules

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbaf92fcfc832ca00f64bd0ad7b4b7