### PR TITLE
Add resolver facts exporter tooling

### DIFF
--- a/resolver/README.md
+++ b/resolver/README.md
@@ -33,3 +33,18 @@ python resolver/tools/freeze_snapshot.py --facts resolver/samples/facts_sample.c
 ```
 
 PR checklist addition: ✅ If this PR changes facts or resolver logic, ensure a snapshot plan is documented and (when appropriate) a new snapshot was produced with the freezer.
+
+## Export → Validate → Freeze (quickstart)
+
+```bash
+# 1) Export normalized facts from staging files/folder
+python resolver/tools/export_facts.py --in resolver/staging --out resolver/exports
+
+# 2) Validate against registries and schema
+python resolver/tools/validate_facts.py --facts resolver/exports/facts.csv
+
+# 3) Freeze a monthly snapshot for grading
+python resolver/tools/freeze_snapshot.py --facts resolver/exports/facts.csv --month 2025-09
+
+
+If you see validation errors, fix the staging inputs or tweak resolver/tools/export_config.yml.

--- a/resolver/exports/README.md
+++ b/resolver/exports/README.md
@@ -1,0 +1,47 @@
+# Exports
+
+This folder receives normalized resolver outputs produced by the exporter:
+
+- `facts.csv` — canonical CSV matching the Data Dictionary
+- `facts.parquet` — same rows in columnar format (optional)
+
+## How to create
+```bash
+pip install pandas pyarrow pyyaml
+python resolver/tools/export_facts.py --in resolver/staging --out resolver/exports
+
+
+Then:
+
+python resolver/tools/validate_facts.py --facts resolver/exports/facts.csv
+python resolver/tools/freeze_snapshot.py --facts resolver/exports/facts.csv --month YYYY-MM
+
+
+---
+
+### 👉 Update: `resolver/README.md` (append this quickstart)
+
+```md
+## Export → Validate → Freeze (quickstart)
+
+```bash
+# 1) Export normalized facts from staging files/folder
+python resolver/tools/export_facts.py --in resolver/staging --out resolver/exports
+
+# 2) Validate against registries and schema
+python resolver/tools/validate_facts.py --facts resolver/exports/facts.csv
+
+# 3) Freeze a monthly snapshot for grading
+python resolver/tools/freeze_snapshot.py --facts resolver/exports/facts.csv --month 2025-09
+
+
+If you see validation errors, fix the staging inputs or tweak resolver/tools/export_config.yml.
+
+
+---
+
+**Definition of Done (DoD)**  
+- `resolver/tools/export_facts.py` and `resolver/tools/export_config.yml` exist with the exact content above.  
+- `resolver/staging/sample_source.csv` and `resolver/exports/README.md` added.  
+- `resolver/README.md` updated with the quickstart.  
+- Local smoke test (on your machine):

--- a/resolver/staging/sample_source.csv
+++ b/resolver/staging/sample_source.csv
@@ -1,0 +1,3 @@
+event_id,country_name,iso3,hazard_code,hazard_label,hazard_class,metric,value,unit,as_of_date,publication_date,publisher,source_type,source_url,doc_title,definition_text,method,confidence,revision,ingested_at
+PHL-TC-2025-09-r1,Philippines,PHL,TC,Tropical Cyclone,natural,affected,125000,persons,2025-09-14,2025-09-15,OCHA,sitrep,https://example.org/sitrep,Flash Update #3,"People affected includes those requiring assistance due to TC...",api,med,1,2025-09-15T12:00:00Z
+ETH-DR-2025-08-r1,Ethiopia,ETH,DR,Drought,natural,in_need,2300000,persons,2025-08-20,2025-08-22,OCHA,appeal,https://example.org/hrp,HRP Addendum,"PIN per HRP addendum methodology.",api,high,1,2025-08-22T10:00:00Z

--- a/resolver/tools/export_config.yml
+++ b/resolver/tools/export_config.yml
@@ -1,0 +1,49 @@
+# Minimal example mapping for staging CSVs like resolver/staging/sample_source.csv
+mapping:
+  event_id:        ["event_id","evt_id"]
+  country_name:    ["country_name","country"]
+  iso3:            ["iso3","iso_code3"]
+  hazard_code:     ["hazard_code","hz_code"]
+  hazard_label:    ["hazard_label","hz_label"]
+  hazard_class:    ["hazard_class","hz_class"]
+  metric:          ["metric","measure"]
+  value:           ["value","count","people"]
+  unit:            ["unit"]
+  as_of_date:      ["as_of_date","as_of"]
+  publication_date:["publication_date","published"]
+  publisher:       ["publisher","org"]
+  source_type:     ["source_type","source"]
+  source_url:      ["source_url","url"]
+  doc_title:       ["doc_title","title"]
+  definition_text: ["definition_text","definition","note"]
+  method:          ["method","ingest_method"]
+  confidence:      ["confidence"]
+  revision:        ["revision","rev"]
+  artifact_id:     ["artifact_id"]
+  artifact_sha256: ["artifact_sha256"]
+  notes:           ["notes"]
+  alt_value:       ["alt_value"]
+  alt_source_url:  ["alt_source_url"]
+  proxy_for:       ["proxy_for"]
+  precedence_decision: ["precedence_decision"]
+  ingested_at:     ["ingested_at"]
+
+# Default fills if missing
+constants:
+  unit: "persons"
+  method: "api"
+  confidence: "med"
+  revision: 1
+
+# Normalize free-text metrics to canonical enums
+transforms:
+  metric:
+    in_need:    ["pin","people_in_need","in need","in-need"]
+    affected:   ["pa","people_affected","affected"]
+    displaced:  ["idps","displaced","internal_displacement"]
+    cases:      ["cases","confirmed_cases","suspected_cases"]
+
+# Alternative date field names if needed
+dates:
+  as_of_date: ["date_as_of","asof"]
+  publication_date: ["pub_date","pub"]

--- a/resolver/tools/export_facts.py
+++ b/resolver/tools/export_facts.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""
+export_facts.py — normalize arbitrary staging inputs into resolver 'facts' outputs.
+
+Examples:
+  # Export from a folder of CSVs using the default mapping config:
+  python resolver/tools/export_facts.py --in resolver/staging --out resolver/exports
+
+  # Export from a single file with explicit config:
+  python resolver/tools/export_facts.py \
+      --in resolver/staging/sample_source.csv \
+      --config resolver/tools/export_config.yml \
+      --out resolver/exports
+
+What it does:
+  - Loads one or many staging files (.csv, .parquet, .json lines)
+  - Applies a column mapping + constant fills from export_config.yml
+  - Coerces datatypes and enums to match the Data Dictionary
+  - Writes 'facts.csv' and 'facts.parquet' to the /resolver/exports/ folder
+  - Prints how many rows written and where
+
+After exporting:
+  - Validate:   python resolver/tools/validate_facts.py --facts resolver/exports/facts.csv
+  - Freeze:     python resolver/tools/freeze_snapshot.py --facts resolver/exports/facts.csv --month YYYY-MM
+"""
+
+import argparse, os, sys, json, datetime as dt
+from pathlib import Path
+from typing import Dict, Any, List
+
+try:
+    import pandas as pd
+except ImportError:
+    print("Please 'pip install pandas pyarrow pyyaml' to run the exporter.", file=sys.stderr)
+    sys.exit(2)
+
+try:
+    import yaml
+except ImportError:
+    print("Please 'pip install pyyaml' to run the exporter.", file=sys.stderr)
+    sys.exit(2)
+
+ROOT = Path(__file__).resolve().parents[1]     # .../resolver
+TOOLS = ROOT / "tools"
+EXPORTS = ROOT / "exports"
+DEFAULT_CONFIG = TOOLS / "export_config.yml"
+
+REQUIRED = [
+    "event_id","country_name","iso3",
+    "hazard_code","hazard_label","hazard_class",
+    "metric","value","unit",
+    "as_of_date","publication_date",
+    "publisher","source_type","source_url","doc_title",
+    "definition_text","method","confidence",
+    "revision","ingested_at"
+]
+
+def _load_config(path: Path) -> Dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+def _read_one(path: Path) -> pd.DataFrame:
+    ext = path.suffix.lower()
+    if ext in [".csv", ".tsv"]:
+        return pd.read_csv(path, dtype=str).fillna("")
+    if ext == ".parquet":
+        return pd.read_parquet(path)
+    if ext in [".json", ".jsonl"]:
+        return pd.read_json(path, lines=True, dtype_backend="pyarrow").astype(str).fillna("")
+    raise SystemExit(f"Unsupported input extension: {ext}")
+
+def _collect_inputs(inp: Path) -> List[Path]:
+    if inp.is_dir():
+        files: List[Path] = []
+        for p in inp.rglob("*"):
+            if p.suffix.lower() in (".csv",".tsv",".parquet",".json",".jsonl"):
+                files.append(p)
+        return files
+    return [inp]
+
+def _apply_mapping(df: pd.DataFrame, cfg: Dict[str, Any]) -> pd.DataFrame:
+    """
+    cfg structure:
+      mapping:
+        event_id: [ "event_id", "evt_id" ]     # take first existing
+        country_name: [ "country", "country_name" ]
+        ...
+      constants:
+        unit: "persons"
+        method: "api"
+        revision: 1
+      transforms:
+        metric:
+          # map source values to canonical
+          affected: ["affected","people_affected","pa"]
+          in_need: ["pin","people_in_need","in_need"]
+      dates:
+        as_of_date: ["as_of","date_as_of"]
+        publication_date: ["pub_date","published"]
+    """
+    mapping = cfg.get("mapping", {})
+    constants = cfg.get("constants", {})
+    transforms = cfg.get("transforms", {})
+    dates = cfg.get("dates", {})
+
+    out = pd.DataFrame()
+
+    # Column mapping: take the first available source column
+    for target, sources in mapping.items():
+        val = None
+        for s in sources:
+            if s in df.columns:
+                val = df[s]
+                break
+        if val is None:
+            out[target] = ""  # will fill from constants/defaults later
+        else:
+            out[target] = val.astype(str).fillna("")
+
+    # Date mapping (same approach)
+    for target, sources in dates.items():
+        if target not in out.columns:
+            out[target] = ""
+        if not out[target].any():
+            for s in sources:
+                if s in df.columns:
+                    out[target] = df[s].astype(str).fillna("")
+                    break
+
+    # Constants/defaults
+    for k, v in constants.items():
+        if k not in out.columns or (out[k] == "").all():
+            out[k] = str(v)
+
+    # Metric transforms
+    if "metric" in transforms:
+        look = {}
+        for canonical, alts in transforms["metric"].items():
+            for a in alts:
+                look[str(a).lower()] = canonical
+        if "metric" in out.columns:
+            out["metric"] = out["metric"].astype(str).str.lower().map(lambda x: look.get(x, x))
+
+    # Fill missing required columns with empty string (we’ll validate later)
+    for col in REQUIRED:
+        if col not in out.columns:
+            out[col] = ""
+
+    # Coerce some types
+    # value should be numeric string; keep as string for consistency; validator enforces numeric
+    # ensure revision and other ints are stringified
+    for c in out.columns:
+        out[c] = out[c].astype(str).fillna("")
+
+    # Add ingested_at if empty
+    if "ingested_at" in out.columns:
+        mask = out["ingested_at"].str.len() == 0
+        if mask.any():
+            ts = dt.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+            out.loc[mask, "ingested_at"] = ts
+
+    return out
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="inp", required=True, help="Path to staging file or directory")
+    ap.add_argument("--config", default=str(DEFAULT_CONFIG), help="Path to export_config.yml")
+    ap.add_argument("--out", default=str(EXPORTS), help="Output directory (will create if needed)")
+    args = ap.parse_args()
+
+    inp = Path(args.inp)
+    cfg_path = Path(args.config)
+    out_dir = Path(args.out)
+
+    if not cfg_path.exists():
+        print(f"Config not found: {cfg_path}", file=sys.stderr)
+        sys.exit(2)
+
+    files = _collect_inputs(inp)
+    if not files:
+        print(f"No supported files found under {inp}", file=sys.stderr)
+        sys.exit(1)
+
+    cfg = _load_config(cfg_path)
+
+    frames = []
+    for f in files:
+        df = _read_one(f)
+        frames.append(df)
+    staging = pd.concat(frames, ignore_index=True) if len(frames) > 1 else frames[0]
+
+    facts = _apply_mapping(staging, cfg)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = out_dir / "facts.csv"
+    pq_path  = out_dir / "facts.parquet"
+    facts.to_csv(csv_path, index=False)
+    try:
+        facts.to_parquet(pq_path, index=False)
+    except Exception as e:
+        print(f"Warning: could not write Parquet ({e}). CSV written.", file=sys.stderr)
+
+    print(f"✅ Exported {len(facts)} rows to:")
+    print(f" - {csv_path}")
+    if pq_path.exists():
+        print(f" - {pq_path}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a configurable staging-to-facts exporter script and default mapping
- document export targets and add a sample staging file for smoke testing
- mention the export/validate/freeze quickstart in the resolver README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbbe9867a4832cbd50053f12e5021d