### PR TITLE
Add ingestion stub scaffolding

### DIFF
--- a/resolver/README.md
+++ b/resolver/README.md
@@ -48,3 +48,31 @@ python resolver/tools/freeze_snapshot.py --facts resolver/exports/facts.csv --mo
 
 
 If you see validation errors, fix the staging inputs or tweak resolver/tools/export_config.yml.
+
+## End-to-end (Stubs → Export → Validate → Freeze)
+
+```bash
+# 0) Ensure registries exist and include your latest countries/hazards
+#    resolver/data/countries.csv
+#    resolver/data/shocks.csv
+
+# 1) Generate staging CSVs from stub connectors (no network)
+python resolver/ingestion/run_all_stubs.py
+
+# 2) Export canonical facts from staging
+python resolver/tools/export_facts.py --in resolver/staging --out resolver/exports
+
+# 3) Validate against registries & schema
+python resolver/tools/validate_facts.py --facts resolver/exports/facts.csv
+
+# 4) Freeze a monthly snapshot
+python resolver/tools/freeze_snapshot.py --facts resolver/exports/facts.csv --month YYYY-MM
+```
+
+This will create:
+
+resolver/staging/*.csv (one per source)
+
+resolver/exports/facts.csv (+ optional Parquet)
+
+resolver/snapshots/YYYY-MM/{facts.parquet,manifest.json}

--- a/resolver/ingestion/README.md
+++ b/resolver/ingestion/README.md
@@ -1,0 +1,41 @@
+# Ingestion (Scaffold)
+
+This folder holds **stub connectors** that generate small **staging CSVs** (no external calls yet).
+They allow you to test the full pipeline now:
+
+**Stubs → Export → Validate → Freeze**
+
+Later (Epic C) we will replace stubs with real API/scraper clients.
+
+## Sources covered (stubs)
+- ReliefWeb (`reliefweb_stub.py`)
+- IFRC GO (`ifrc_go_stub.py`)
+- UNHCR ODP (`unhcr_stub.py`)
+- IOM DTM (`dtm_stub.py`)
+- WHO Emergencies (`who_stub.py`)
+- IPC (`ipc_stub.py`)
+
+Each stub:
+- Reads `resolver/data/countries.csv` and `resolver/data/shocks.csv`
+- Produces `resolver/staging/<source>.csv` using the exporter’s expected columns
+
+## Run all stubs
+
+```bash
+python resolver/ingestion/run_all_stubs.py
+
+
+Then:
+
+python resolver/tools/export_facts.py --in resolver/staging --out resolver/exports
+python resolver/tools/validate_facts.py --facts resolver/exports/facts.csv
+python resolver/tools/freeze_snapshot.py --facts resolver/exports/facts.csv --month YYYY-MM
+```
+
+Notes
+
+Stubs are deterministic samples for now (no network). Replace their internal make_rows() with real pulls in Epic C.
+
+Hazards must match resolver/data/shocks.csv (e.g., FL, DR, TC, HW, ACO, ACE, ACC, DI, CU, EC, PHE).
+
+Earthquakes are out of scope by policy and are not included in stubs.

--- a/resolver/ingestion/_stub_utils.py
+++ b/resolver/ingestion/_stub_utils.py
@@ -1,0 +1,38 @@
+import datetime as dt
+from pathlib import Path
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA = ROOT / "data"
+STAGING = ROOT / "staging"
+
+COUNTRIES = DATA / "countries.csv"
+SHOCKS = DATA / "shocks.csv"
+
+REQUIRED_COLUMNS = [
+    "event_id","country_name","iso3",
+    "hazard_code","hazard_label","hazard_class",
+    "metric","value","unit",
+    "as_of_date","publication_date",
+    "publisher","source_type","source_url","doc_title",
+    "definition_text","method","confidence",
+    "revision","ingested_at"
+]
+
+def load_registries():
+    c = pd.read_csv(COUNTRIES, dtype=str).fillna("")
+    s = pd.read_csv(SHOCKS, dtype=str).fillna("")
+    return c, s
+
+def now_dates():
+    today = dt.date.today()
+    as_of = today.strftime("%Y-%m-%d")
+    pub = today.strftime("%Y-%m-%d")
+    ing = dt.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    return as_of, pub, ing
+
+def write_staging(rows, out_path: Path):
+    df = pd.DataFrame(rows, columns=REQUIRED_COLUMNS)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(out_path, index=False)
+    return out_path

--- a/resolver/ingestion/checklist.yml
+++ b/resolver/ingestion/checklist.yml
@@ -1,0 +1,35 @@
+# Ingestion Checklist (C1 → C2)
+sources:
+  reliefweb:
+    cadence: high
+    output: resolver/staging/reliefweb.csv
+    owner: ingestion
+    status: stub
+  ifrc_go:
+    cadence: high
+    output: resolver/staging/ifrc_go.csv
+    owner: ingestion
+    status: stub
+  unhcr_odp:
+    cadence: medium
+    output: resolver/staging/unhcr.csv
+    owner: ingestion
+    status: stub
+  iom_dtm:
+    cadence: medium
+    output: resolver/staging/dtm.csv
+    owner: ingestion
+    status: stub
+  who_emergencies:
+    cadence: high
+    output: resolver/staging/who.csv
+    owner: ingestion
+    status: stub
+  ipc:
+    cadence: low
+    output: resolver/staging/ipc.csv
+    owner: ingestion
+    status: stub
+notes:
+  - Replace "stub" with "api" when real connectors land in Epic C.
+  - All outputs must validate with resolver/tools/validate_facts.py

--- a/resolver/ingestion/dtm_stub.py
+++ b/resolver/ingestion/dtm_stub.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+from pathlib import Path
+from _stub_utils import load_registries, now_dates, write_staging
+
+OUT = Path(__file__).resolve().parents[1] / "staging" / "dtm.csv"
+
+def make_rows():
+    countries, shocks = load_registries()
+    as_of, pub, ing = now_dates()
+
+    hz = shocks[shocks["hazard_code"].isin(["ACE","CU"])]
+
+    rows = []
+    sample = countries.sample(min(2, len(countries)), random_state=11)
+    for _, c in sample.iterrows():
+        for _, h in hz.iterrows():
+            event_id = f"{c.iso3}-{h.hazard_code}-dtm-stub-r1"
+            rows.append([
+                event_id, c.country_name, c.iso3,
+                h.hazard_code, h.hazard_label, h.hazard_class,
+                "displaced", "18000", "persons",
+                as_of, pub,
+                "IOM-DTM", "cluster", "https://example.org/dtm", f"{h.hazard_label} Displacement Round",
+                f"New internal displacement attributed to {h.hazard_label}.",
+                "api", "med", 1, ing
+            ])
+    return rows
+
+if __name__ == "__main__":
+    p = write_staging(make_rows(), OUT)
+    print(f"wrote {p}")

--- a/resolver/ingestion/ifrc_go_stub.py
+++ b/resolver/ingestion/ifrc_go_stub.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+from pathlib import Path
+from _stub_utils import load_registries, now_dates, write_staging
+
+OUT = Path(__file__).resolve().parents[1] / "staging" / "ifrc_go.csv"
+
+def make_rows():
+    countries, shocks = load_registries()
+    as_of, pub, ing = now_dates()
+
+    ctry = countries.tail(2)
+    hz = shocks[shocks["hazard_code"].isin(["FL","TC"])]
+
+    rows = []
+    for _, c in ctry.iterrows():
+        for _, h in hz.iterrows():
+            event_id = f"{c.iso3}-{h.hazard_code}-ifrc-stub-r1"
+            rows.append([
+                event_id, c.country_name, c.iso3,
+                h.hazard_code, h.hazard_label, h.hazard_class,
+                "affected", "75000", "persons",
+                as_of, pub,
+                "IFRC", "sitrep", "https://example.org/ifrc", f"{h.hazard_label} DREF",
+                f"People affected per IFRC GO DREF for {h.hazard_label}.",
+                "api", "med", 1, ing
+            ])
+    return rows
+
+if __name__ == "__main__":
+    p = write_staging(make_rows(), OUT)
+    print(f"wrote {p}")

--- a/resolver/ingestion/ipc_stub.py
+++ b/resolver/ingestion/ipc_stub.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+from pathlib import Path
+from _stub_utils import load_registries, now_dates, write_staging
+
+OUT = Path(__file__).resolve().parents[1] / "staging" / "ipc.csv"
+
+def make_rows():
+    countries, shocks = load_registries()
+    as_of, pub, ing = now_dates()
+
+    hz = shocks[shocks["hazard_code"].isin(["DR","EC"])]
+
+    rows = []
+    sample = countries.sample(min(2, len(countries)), random_state=17)
+    for _, c in sample.iterrows():
+        for _, h in hz.iterrows():
+            event_id = f"{c.iso3}-{h.hazard_code}-ipc-stub-r1"
+            rows.append([
+                event_id, c.country_name, c.iso3,
+                h.hazard_code, h.hazard_label, h.hazard_class,
+                "affected", "2100000", "persons",
+                as_of, pub,
+                "IPC", "cluster", "https://example.org/ipc", f"{h.hazard_label} IPC Projection",
+                f"Phase 3+ population used as proxy for PIN in {c.country_name}.",
+                "manual", "med", 1, ing
+            ])
+    return rows
+
+if __name__ == "__main__":
+    p = write_staging(make_rows(), OUT)
+    print(f"wrote {p}")

--- a/resolver/ingestion/reliefweb_stub.py
+++ b/resolver/ingestion/reliefweb_stub.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+from pathlib import Path
+from _stub_utils import load_registries, now_dates, write_staging
+
+OUT = Path(__file__).resolve().parents[1] / "staging" / "reliefweb.csv"
+
+def make_rows():
+    countries, shocks = load_registries()
+    as_of, pub, ing = now_dates()
+
+    ctry = countries.head(2)
+    hz = shocks[shocks["hazard_code"].isin(["FL","TC","HW"])]
+
+    rows = []
+    for _, c in ctry.iterrows():
+        for _, h in hz.iterrows():
+            event_id = f"{c.iso3}-{h.hazard_code}-reliefweb-stub-r1"
+            rows.append([
+                event_id, c.country_name, c.iso3,
+                h.hazard_code, h.hazard_label, h.hazard_class,
+                "affected", "100000", "persons",
+                as_of, pub,
+                "OCHA", "sitrep", "https://example.org/reliefweb", f"{h.hazard_label} Sitrep",
+                f"People affected per OCHA sitrep for {h.hazard_label}.",
+                "api", "med", 1, ing
+            ])
+    return rows
+
+if __name__ == "__main__":
+    p = write_staging(make_rows(), OUT)
+    print(f"wrote {p}")

--- a/resolver/ingestion/run_all_stubs.py
+++ b/resolver/ingestion/run_all_stubs.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+Run all ingestion stubs to populate resolver/staging/*.csv
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+STUBS = [
+    "reliefweb_stub.py",
+    "ifrc_go_stub.py",
+    "unhcr_stub.py",
+    "dtm_stub.py",
+    "who_stub.py",
+    "ipc_stub.py",
+]
+
+def main():
+    failed = 0
+    for stub in STUBS:
+        path = ROOT / stub
+        print(f"==> running {stub}")
+        res = subprocess.run([sys.executable, str(path)])
+        if res.returncode != 0:
+            failed += 1
+    if failed:
+        print(f"{failed} stub(s) failed", file=sys.stderr)
+        sys.exit(1)
+    print("✅ all stubs completed")
+
+if __name__ == "__main__":
+    main()

--- a/resolver/ingestion/unhcr_stub.py
+++ b/resolver/ingestion/unhcr_stub.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+from pathlib import Path
+from _stub_utils import load_registries, now_dates, write_staging
+
+OUT = Path(__file__).resolve().parents[1] / "staging" / "unhcr.csv"
+
+def make_rows():
+    countries, shocks = load_registries()
+    as_of, pub, ing = now_dates()
+
+    hz_codes = ["DI","ACE"]
+    hz = shocks[shocks["hazard_code"].isin(hz_codes)]
+
+    rows = []
+    sample = countries.sample(min(2, len(countries)), random_state=7)
+    for _, c in sample.iterrows():
+        for _, h in hz.iterrows():
+            event_id = f"{c.iso3}-{h.hazard_code}-unhcr-stub-r1"
+            rows.append([
+                event_id, c.country_name, c.iso3,
+                h.hazard_code, h.hazard_label, h.hazard_class,
+                "displaced", "25000", "persons",
+                as_of, pub,
+                "UNHCR", "cluster", "https://example.org/unhcr", f"{h.hazard_label} Update",
+                f"Population displacement associated with {h.hazard_label}.",
+                "api", "med", 1, ing
+            ])
+    return rows
+
+if __name__ == "__main__":
+    p = write_staging(make_rows(), OUT)
+    print(f"wrote {p}")

--- a/resolver/ingestion/who_stub.py
+++ b/resolver/ingestion/who_stub.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+from pathlib import Path
+from _stub_utils import load_registries, now_dates, write_staging
+
+OUT = Path(__file__).resolve().parents[1] / "staging" / "who.csv"
+
+def make_rows():
+    countries, shocks = load_registries()
+    as_of, pub, ing = now_dates()
+
+    hz = shocks[shocks["hazard_code"].isin(["PHE"])]
+
+    rows = []
+    sample = countries.sample(min(2, len(countries)), random_state=13)
+    for _, c in sample.iterrows():
+        for _, h in hz.iterrows():
+            event_id = f"{c.iso3}-{h.hazard_code}-who-stub-r1"
+            rows.append([
+                event_id, c.country_name, c.iso3,
+                h.hazard_code, h.hazard_label, h.hazard_class,
+                "cases", "3200", "persons_cases",
+                as_of, pub,
+                "WHO", "sitrep", "https://example.org/who", f"{h.hazard_label} DON",
+                f"Case counts for {h.hazard_label}. Not equivalent to PIN.",
+                "api", "low", 1, ing
+            ])
+    return rows
+
+if __name__ == "__main__":
+    p = write_staging(make_rows(), OUT)
+    print(f"wrote {p}")


### PR DESCRIPTION
## Summary
- add ingestion README and checklist for the stub connector scaffold
- implement stub utilities, six connector scripts, and a runner that writes staging CSVs
- extend the resolver README with end-to-end quickstart instructions

## Testing
- python resolver/ingestion/run_all_stubs.py

------
https://chatgpt.com/codex/tasks/task_e_68dbc4c26ee4832c9ba8e5f235683a85