### PR TITLE
Add definition of done to ingestion quickstart docs

### DIFF
--- a/resolver/README.md
+++ b/resolver/README.md
@@ -76,3 +76,12 @@ resolver/staging/*.csv (one per source)
 resolver/exports/facts.csv (+ optional Parquet)
 
 resolver/snapshots/YYYY-MM/{facts.parquet,manifest.json}
+
+
+---
+
+**Definition of Done (DoD)**  
+- `resolver/ingestion/README.md` + `resolver/ingestion/checklist.yml` exist.  
+- Stubs exist and write staging CSVs: `reliefweb.csv`, `ifrc_go.csv`, `unhcr.csv`, `dtm.csv`, `who.csv`, `ipc.csv`.  
+- `run_all_stubs.py` runs all stubs and prints **✅ all stubs completed**.  
+- Root `resolver/README.md` shows the end-to-end commands.


### PR DESCRIPTION
## Summary
- add the definition of done checklist to the ingestion quickstart section so the stub deliverables are explicit

## Testing
- python resolver/ingestion/run_all_stubs.py

------
https://chatgpt.com/codex/tasks/task_e_68dbc91541d8832cab8362fe063f759c