### PR TITLE
[resolver] Add extended ingestion stubs for additional sources

### DIFF
--- a/resolver/ingestion/README.md
+++ b/resolver/ingestion/README.md
@@ -14,6 +14,16 @@ Later (Epic C) we will replace stubs with real API/scraper clients.
 - IOM DTM (`dtm_stub.py`)
 - WHO Emergencies (`who_stub.py`)
 - IPC (`ipc_stub.py`)
+- EM-DAT (`emdat_stub.py`)
+- GDACS (`gdacs_stub.py`)
+- Copernicus EMS (`copernicus_stub.py`)
+- UNOSAT (`unosat_stub.py`)
+- HDX (CKAN) (`hdx_stub.py`)
+- ACLED (`acled_stub.py`)
+- UCDP (`ucdp_stub.py`)
+- FEWS NET (`fews_stub.py`)
+- WFP mVAM (`wfp_mvam_stub.py`)
+- Gov NDMA (`gov_ndma_stub.py`)
 
 Each stub:
 - Reads `resolver/data/countries.csv` and `resolver/data/shocks.csv`
@@ -39,3 +49,16 @@ Stubs are deterministic samples for now (no network). Replace their internal mak
 Hazards must match resolver/data/shocks.csv (e.g., FL, DR, TC, HW, ACO, ACE, ACC, DI, CU, EC, PHE).
 
 Earthquakes are out of scope by policy and are not included in stubs.
+
+## Source notes (what each adds)
+
+- **EM-DAT** — standardized disaster records and “people affected”; lagged but consistent.
+- **GDACS** — near-real-time alerts and modeled impact for hydro-meteo hazards.
+- **Copernicus EMS / UNOSAT** — activation footprints, damage/exposure mapping (good PA proxies).
+- **HDX (CKAN)** — dataset discovery hub; many country datasets flow here.
+- **ACLED / UCDP** — conflict event data (drivers/attribution context; not PIN).
+- **FEWS NET** — early warning analyses; aligns with IPC phases for DR/EC.
+- **WFP mVAM** — market/price/food security indicators (context for EC/DR).
+- **Gov NDMA** — national sitreps; often earliest official “people affected”.
+
+> **Reminder:** Stubs emit plausible demo rows only. Final **resolution** still follows A2 precedence (PIN preferred; PA proxy), and Tier-2/3 sources should not override Tier-1.

--- a/resolver/ingestion/acled_stub.py
+++ b/resolver/ingestion/acled_stub.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+from pathlib import Path
+from _stub_utils import load_registries, now_dates, write_staging
+
+OUT = Path(__file__).resolve().parents[1] / "staging" / "acled.csv"
+
+def make_rows():
+    countries, shocks = load_registries()
+    as_of, pub, ing = now_dates()
+    # ACLED: conflict events — in real connector, we'd pull event counts; here we emit a proxy affected number for demo
+    hz = shocks[shocks["hazard_code"].isin(["ACE", "CU"])]
+    rows = []
+    for _, c in countries.sample(min(2, len(countries)), random_state=27).iterrows():
+        for _, h in hz.head(1).iterrows():
+            event_id = f"{c.iso3}-{h.hazard_code}-acled-stub-r1"
+            rows.append([
+                event_id, c.country_name, c.iso3,
+                h.hazard_code, h.hazard_label, h.hazard_class,
+                "affected", "12000", "persons",
+                as_of, pub,
+                "ACLED", "agency", "https://example.org/acled", f"{h.hazard_label} Events (proxy)",
+                "Conflict event volumes; affected number is a placeholder proxy (not for final resolution).",
+                "api", "low", 1, ing
+            ])
+    return rows
+
+if __name__ == "__main__":
+    print(write_staging(make_rows(), OUT))

--- a/resolver/ingestion/checklist.yml
+++ b/resolver/ingestion/checklist.yml
@@ -30,6 +30,56 @@ sources:
     output: resolver/staging/ipc.csv
     owner: ingestion
     status: stub
+  emdat:
+    cadence: low
+    output: resolver/staging/emdat.csv
+    owner: ingestion
+    status: stub   # real: bulk CSV export; standardized "people affected"
+  gdacs:
+    cadence: high
+    output: resolver/staging/gdacs.csv
+    owner: ingestion
+    status: stub   # real: JSON/RSS feeds; near-real-time alerts & modeled impact
+  copernicus_ems:
+    cadence: medium
+    output: resolver/staging/copernicus.csv
+    owner: ingestion
+    status: stub   # real: activation API/pages; footprint/exposure products
+  unosat:
+    cadence: medium
+    output: resolver/staging/unosat.csv
+    owner: ingestion
+    status: stub   # real: map services/WMS; damage assessments
+  hdx_ckan:
+    cadence: medium
+    output: resolver/staging/hdx.csv
+    owner: ingestion
+    status: stub   # real: CKAN API for dataset discovery (country/hazard filters)
+  acled:
+    cadence: high
+    output: resolver/staging/acled.csv
+    owner: ingestion
+    status: stub   # real: API requires key; conflict event volumes
+  ucdp:
+    cadence: medium
+    output: resolver/staging/ucdp.csv
+    owner: ingestion
+    status: stub   # real: open API; conflict datasets
+  fews_net:
+    cadence: low
+    output: resolver/staging/fews.csv
+    owner: ingestion
+    status: stub   # real: CSV/portal; early warning narrative & phase mapping
+  wfp_mvam:
+    cadence: medium
+    output: resolver/staging/wfp_mvam.csv
+    owner: ingestion
+    status: stub   # real: price/food security indicators where available
+  gov_ndma:
+    cadence: high
+    output: resolver/staging/gov_ndma.csv
+    owner: ingestion
+    status: stub   # real: per-country feeds/RSS; official sitreps
 notes:
   - Replace "stub" with "api" when real connectors land in Epic C.
   - All outputs must validate with resolver/tools/validate_facts.py

--- a/resolver/ingestion/copernicus_stub.py
+++ b/resolver/ingestion/copernicus_stub.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+from pathlib import Path
+from _stub_utils import load_registries, now_dates, write_staging
+
+OUT = Path(__file__).resolve().parents[1] / "staging" / "copernicus.csv"
+
+def make_rows():
+    countries, shocks = load_registries()
+    as_of, pub, ing = now_dates()
+    # Copernicus EMS: mapping of activation footprint; we record affected as exposure proxy
+    hz = shocks[shocks["hazard_code"].isin(["FL", "TC", "HW"])]
+    rows = []
+    for _, c in countries.sample(min(2, len(countries)), random_state=21).iterrows():
+        for _, h in hz.head(1).iterrows():
+            event_id = f"{c.iso3}-{h.hazard_code}-copernicus-stub-r1"
+            rows.append([
+                event_id, c.country_name, c.iso3,
+                h.hazard_code, h.hazard_label, h.hazard_class,
+                "affected", "14000", "persons",
+                as_of, pub,
+                "Copernicus EMS", "agency", "https://example.org/copernicus", f"{h.hazard_label} Activation",
+                "Population exposure estimated from activation footprint (proxy).",
+                "api", "low", 1, ing
+            ])
+    return rows
+
+if __name__ == "__main__":
+    print(write_staging(make_rows(), OUT))

--- a/resolver/ingestion/emdat_stub.py
+++ b/resolver/ingestion/emdat_stub.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+from pathlib import Path
+from _stub_utils import load_registries, now_dates, write_staging
+
+OUT = Path(__file__).resolve().parents[1] / "staging" / "emdat.csv"
+
+def make_rows():
+    countries, shocks = load_registries()
+    as_of, pub, ing = now_dates()
+    # EM-DAT: standardized disaster impacts (lagged). Use natural hazards (no earthquakes in scope).
+    hz = shocks[shocks["hazard_code"].isin(["FL", "TC", "HW", "DR"])]
+    rows = []
+    for _, c in countries.head(2).iterrows():
+        for _, h in hz.head(1).iterrows():
+            event_id = f"{c.iso3}-{h.hazard_code}-emdat-stub-r1"
+            rows.append([
+                event_id, c.country_name, c.iso3,
+                h.hazard_code, h.hazard_label, h.hazard_class,
+                "affected", "56000", "persons",
+                as_of, pub,
+                "EM-DAT", "agency", "https://example.org/emdat", f"{h.hazard_label} Event Record",
+                "People affected per standardized EM-DAT disaster record.",
+                "api", "med", 1, ing
+            ])
+    return rows
+
+if __name__ == "__main__":
+    print(write_staging(make_rows(), OUT))

--- a/resolver/ingestion/fews_stub.py
+++ b/resolver/ingestion/fews_stub.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+from pathlib import Path
+from _stub_utils import load_registries, now_dates, write_staging
+
+OUT = Path(__file__).resolve().parents[1] / "staging" / "fews.csv"
+
+def make_rows():
+    countries, shocks = load_registries()
+    as_of, pub, ing = now_dates()
+    # FEWS NET: early warning; we align to DR/EC hazards when PIN missing
+    hz = shocks[shocks["hazard_code"].isin(["DR", "EC"])]
+    rows = []
+    for _, c in countries.sample(min(2, len(countries)), random_state=33).iterrows():
+        for _, h in hz.head(1).iterrows():
+            event_id = f"{c.iso3}-{h.hazard_code}-fews-stub-r1"
+            rows.append([
+                event_id, c.country_name, c.iso3,
+                h.hazard_code, h.hazard_label, h.hazard_class,
+                "affected", "1800000", "persons",
+                as_of, pub,
+                "FEWS NET", "agency", "https://example.org/fews", f"{h.hazard_label} Outlook",
+                "Projected food insecurity proxy aligned to IPC where available.",
+                "manual", "med", 1, ing
+            ])
+    return rows
+
+if __name__ == "__main__":
+    print(write_staging(make_rows(), OUT))

--- a/resolver/ingestion/gdacs_stub.py
+++ b/resolver/ingestion/gdacs_stub.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+from pathlib import Path
+from _stub_utils import load_registries, now_dates, write_staging
+
+OUT = Path(__file__).resolve().parents[1] / "staging" / "gdacs.csv"
+
+def make_rows():
+    countries, shocks = load_registries()
+    as_of, pub, ing = now_dates()
+    # GDACS: near-real-time alerts; modeled impact for hydro-meteo hazards
+    hz = shocks[shocks["hazard_code"].isin(["FL", "TC", "HW"])]
+    rows = []
+    for _, c in countries.tail(2).iterrows():
+        for _, h in hz.head(1).iterrows():
+            event_id = f"{c.iso3}-{h.hazard_code}-gdacs-stub-r1"
+            rows.append([
+                event_id, c.country_name, c.iso3,
+                h.hazard_code, h.hazard_label, h.hazard_class,
+                "affected", "32000", "persons",
+                as_of, pub,
+                "GDACS", "agency", "https://example.org/gdacs", f"{h.hazard_label} Alert",
+                "Modeled affected population estimate for alert footprint (indicative).",
+                "api", "low", 1, ing
+            ])
+    return rows
+
+if __name__ == "__main__":
+    print(write_staging(make_rows(), OUT))

--- a/resolver/ingestion/gov_ndma_stub.py
+++ b/resolver/ingestion/gov_ndma_stub.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+from pathlib import Path
+from _stub_utils import load_registries, now_dates, write_staging
+
+OUT = Path(__file__).resolve().parents[1] / "staging" / "gov_ndma.csv"
+
+def make_rows():
+    countries, shocks = load_registries()
+    as_of, pub, ing = now_dates()
+    # Government NDMA: official sitreps; good for PA when PIN not yet out
+    hz = shocks[shocks["hazard_code"].isin(["FL", "TC", "HW", "CU"])]
+    rows = []
+    for _, c in countries.head(2).iterrows():
+        for _, h in hz.head(1).iterrows():
+            event_id = f"{c.iso3}-{h.hazard_code}-ndma-stub-r1"
+            rows.append([
+                event_id, c.country_name, c.iso3,
+                h.hazard_code, h.hazard_label, h.hazard_class,
+                "affected", "42000", "persons",
+                as_of, pub,
+                "NDMA", "gov", "https://example.org/ndma", f"{h.hazard_label} Gov Sitrep",
+                "Official government 'people affected' total (subject to revision).",
+                "api", "med", 1, ing
+            ])
+    return rows
+
+if __name__ == "__main__":
+    print(write_staging(make_rows(), OUT))

--- a/resolver/ingestion/hdx_stub.py
+++ b/resolver/ingestion/hdx_stub.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+from pathlib import Path
+from _stub_utils import load_registries, now_dates, write_staging
+
+OUT = Path(__file__).resolve().parents[1] / "staging" / "hdx.csv"
+
+def make_rows():
+    countries, shocks = load_registries()
+    as_of, pub, ing = now_dates()
+    rows = []
+    for _, c in countries.head(1).iterrows():
+        event_id = f"{c.iso3}-MIX-hdx-stub-r1"
+        rows.append([
+            event_id, c.country_name, c.iso3,
+            "DR", "Drought", "natural",
+            "affected", "500000", "persons",
+            as_of, pub,
+            "HDX (CKAN)", "agency", "https://example.org/hdx", "Dataset Snapshot",
+            "Aggregated affected estimate from country dataset discovery (proxy).",
+            "api", "low", 1, ing
+        ])
+    return rows
+
+if __name__ == "__main__":
+    print(write_staging(make_rows(), OUT))

--- a/resolver/ingestion/run_all_stubs.py
+++ b/resolver/ingestion/run_all_stubs.py
@@ -15,6 +15,16 @@ STUBS = [
     "dtm_stub.py",
     "who_stub.py",
     "ipc_stub.py",
+    "emdat_stub.py",
+    "gdacs_stub.py",
+    "copernicus_stub.py",
+    "unosat_stub.py",
+    "hdx_stub.py",
+    "acled_stub.py",
+    "ucdp_stub.py",
+    "fews_stub.py",
+    "wfp_mvam_stub.py",
+    "gov_ndma_stub.py",
 ]
 
 def main():

--- a/resolver/ingestion/ucdp_stub.py
+++ b/resolver/ingestion/ucdp_stub.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+from pathlib import Path
+from _stub_utils import load_registries, now_dates, write_staging
+
+OUT = Path(__file__).resolve().parents[1] / "staging" / "ucdp.csv"
+
+def make_rows():
+    countries, shocks = load_registries()
+    as_of, pub, ing = now_dates()
+    hz = shocks[shocks["hazard_code"].isin(["ACE", "ACO", "ACC"])]
+    rows = []
+    for _, c in countries.sample(min(2, len(countries)), random_state=31).iterrows():
+        for _, h in hz.head(1).iterrows():
+            event_id = f"{c.iso3}-{h.hazard_code}-ucdp-stub-r1"
+            rows.append([
+                event_id, c.country_name, c.iso3,
+                h.hazard_code, h.hazard_label, h.hazard_class,
+                "affected", "8000", "persons",
+                as_of, pub,
+                "UCDP", "agency", "https://example.org/ucdp", f"{h.hazard_label} Events (proxy)",
+                "Conflict dataset context; affected number is a placeholder proxy.",
+                "api", "low", 1, ing
+            ])
+    return rows
+
+if __name__ == "__main__":
+    print(write_staging(make_rows(), OUT))

--- a/resolver/ingestion/unosat_stub.py
+++ b/resolver/ingestion/unosat_stub.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+from pathlib import Path
+from _stub_utils import load_registries, now_dates, write_staging
+
+OUT = Path(__file__).resolve().parents[1] / "staging" / "unosat.csv"
+
+def make_rows():
+    countries, shocks = load_registries()
+    as_of, pub, ing = now_dates()
+    # UNOSAT: damage assessments; use as exposure/affected proxy
+    hz = shocks[shocks["hazard_code"].isin(["FL", "TC", "HW", "CU", "ACE"])]
+    rows = []
+    for _, c in countries.sample(min(2, len(countries)), random_state=23).iterrows():
+        for _, h in hz.head(1).iterrows():
+            event_id = f"{c.iso3}-{h.hazard_code}-unosat-stub-r1"
+            rows.append([
+                event_id, c.country_name, c.iso3,
+                h.hazard_code, h.hazard_label, h.hazard_class,
+                "affected", "9000", "persons",
+                as_of, pub,
+                "UNOSAT", "agency", "https://example.org/unosat", f"{h.hazard_label} Damage Assessment",
+                "Exposure proxy derived from building damage mapping (illustrative).",
+                "api", "low", 1, ing
+            ])
+    return rows
+
+if __name__ == "__main__":
+    print(write_staging(make_rows(), OUT))

--- a/resolver/ingestion/wfp_mvam_stub.py
+++ b/resolver/ingestion/wfp_mvam_stub.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+from pathlib import Path
+from _stub_utils import load_registries, now_dates, write_staging
+
+OUT = Path(__file__).resolve().parents[1] / "staging" / "wfp_mvam.csv"
+
+def make_rows():
+    countries, shocks = load_registries()
+    as_of, pub, ing = now_dates()
+    # WFP mVAM/price bulletins: context for EC/DR
+    hz = shocks[shocks["hazard_code"].isin(["EC", "DR"])]
+    rows = []
+    for _, c in countries.sample(min(2, len(countries)), random_state=35).iterrows():
+        for _, h in hz.head(1).iterrows():
+            event_id = f"{c.iso3}-{h.hazard_code}-wfp-mvam-stub-r1"
+            rows.append([
+                event_id, c.country_name, c.iso3,
+                h.hazard_code, h.hazard_label, h.hazard_class,
+                "affected", "300000", "persons",
+                as_of, pub,
+                "WFP mVAM", "agency", "https://example.org/wfp", f"{h.hazard_label} Bulletin",
+                "Market/food security indicator as affected proxy; not final PIN.",
+                "manual", "low", 1, ing
+            ])
+    return rows
+
+if __name__ == "__main__":
+    print(write_staging(make_rows(), OUT))


### PR DESCRIPTION
## Summary
- add stub connectors for EM-DAT, GDACS, Copernicus EMS, UNOSAT, HDX, ACLED, UCDP, FEWS NET, WFP mVAM, and Gov NDMA
- update the ingestion checklist and documentation to reflect the broader coverage
- run every new stub from the consolidated runner

## Testing
- python resolver/ingestion/run_all_stubs.py

------
https://chatgpt.com/codex/tasks/task_e_68dbcbfba16c832cb883360eaff6ea93