### PR TITLE
Add precedence engine for resolver cutoff selection

### DIFF
--- a/resolver/README.md
+++ b/resolver/README.md
@@ -78,10 +78,37 @@ resolver/exports/facts.csv (+ optional Parquet)
 resolver/snapshots/YYYY-MM/{facts.parquet,manifest.json}
 
 
+## Resolve at a cutoff (precedence engine)
+
+Select one authoritative total per `(iso3, hazard_code)` applying A2 policy:
+
+```bash
+pip install pandas pyarrow pyyaml python-dateutil
+python resolver/tools/precedence_engine.py \
+  --facts resolver/exports/facts.csv \
+  --cutoff 2025-09-30
+```
+
+
+Outputs:
+
+resolver/exports/resolved.csv
+
+resolver/exports/resolved.jsonl
+
+resolver/exports/resolved_diagnostics.csv (conflict notes)
+
+PR checklist addition: ✅ Precedence config reviewed (tools/precedence_config.yml) and results inspected (exports/resolved*.{csv,jsonl}).
+
+
 ---
 
-**Definition of Done (DoD)**  
-- `resolver/ingestion/README.md` + `resolver/ingestion/checklist.yml` exist.  
-- Stubs exist and write staging CSVs: `reliefweb.csv`, `ifrc_go.csv`, `unhcr.csv`, `dtm.csv`, `who.csv`, `ipc.csv`.  
-- `run_all_stubs.py` runs all stubs and prints **✅ all stubs completed**.  
+**Definition of Done (DoD)**
+- `resolver/ingestion/README.md` + `resolver/ingestion/checklist.yml` exist.
+- Stubs exist and write staging CSVs: `reliefweb.csv`, `ifrc_go.csv`, `unhcr.csv`, `dtm.csv`, `who.csv`, `ipc.csv`.
+- `run_all_stubs.py` runs all stubs and prints **✅ all stubs completed**.
 - Root `resolver/README.md` shows the end-to-end commands.
+- `resolver/tools/precedence_config.yml` exists with tiers and mapping that match A2.
+- `resolver/tools/precedence_engine.py` runs on your exported facts and writes `resolved.csv/jsonl` + diagnostics.
+- A local smoke test with `resolver/exports/facts_minimal.csv` succeeds and selects the expected rows.
+- `resolver/README.md` updated with usage and a PR checklist line.

--- a/resolver/exports/facts_minimal.csv
+++ b/resolver/exports/facts_minimal.csv
@@ -1,0 +1,4 @@
+event_id,country_name,iso3,hazard_code,hazard_label,hazard_class,metric,value,unit,as_of_date,publication_date,publisher,source_type,source_url,doc_title,definition_text,method,confidence,revision,ingested_at
+PHL-TC-1,Philippines,PHL,TC,Tropical Cyclone,natural,affected,100000,persons,2025-09-14,2025-09-15,OCHA,sitrep,https://ocha.example/tc,TC Update,"Affected includes those requiring assistance.",api,med,1,2025-09-15T10:00:00Z
+PHL-TC-2,Philippines,PHL,TC,Tropical Cyclone,natural,affected,75000,persons,2025-09-14,2025-09-16,IFRC,sitrep,https://ifrc.example/tc,DREF,"Affected per IFRC GO.",api,med,1,2025-09-16T11:00:00Z
+ETH-DR-1,Ethiopia,ETH,DR,Drought,natural,in_need,2300000,persons,2025-08-20,2025-08-22,OCHA,appeal,https://ocha.example/hrp,HRP Addendum,"PIN per HRP addendum.",api,high,1,2025-08-22T10:00:00Z

--- a/resolver/exports/resolved_minimal_expected.csv
+++ b/resolver/exports/resolved_minimal_expected.csv
@@ -1,0 +1,3 @@
+iso3,hazard_code,hazard_label,hazard_class,metric,value,unit,as_of_date,publication_date,publisher,source_type,source_url,doc_title,definition_text,precedence_tier,event_id,proxy_for,confidence
+ETH,DR,Drought,natural,in_need,2300000,persons,2025-08-20,2025-08-22,OCHA,appeal,https://ocha.example/hrp,HRP Addendum,PIN per HRP addendum.,inter_agency_plan,ETH-DR-1,,high
+PHL,TC,Tropical Cyclone,natural,affected,100000,persons,2025-09-14,2025-09-15,OCHA,sitrep,https://ocha.example/tc,TC Update,Affected includes those requiring assistance.,inter_agency_plan,PHL-TC-1,,med

--- a/resolver/tools/precedence_config.yml
+++ b/resolver/tools/precedence_config.yml
@@ -1,0 +1,37 @@
+# Policy knobs (kept here so we don't hardcode in code)
+metric_preference: [in_need, affected]   # PIN first, else PA
+source_precedence:                       # highest → lowest
+  - inter_agency_plan
+  - ifrc_or_gov_sitrep
+  - un_cluster_snapshot
+  - reputable_ingo_un
+  - agency                               # generic agency
+  - media_discovery_only
+
+# Map source_type/publisher patterns to the policy tiers above
+source_mapping:
+  inter_agency_plan:
+    source_type: ["appeal", "sitrep"]
+    publisher: ["OCHA"]                  # includes HNO/HRP/Flash/Addendum, OCHA sitreps
+  ifrc_or_gov_sitrep:
+    source_type: ["sitrep", "gov"]
+    publisher: ["IFRC", "NDMA", "AFAD", "NDRMC"]
+  un_cluster_snapshot:
+    source_type: ["cluster"]
+    publisher: ["UNHCR", "IOM-DTM", "WHO", "IPC"]
+  reputable_ingo_un:
+    source_type: ["agency"]
+    publisher: ["EM-DAT", "GDACS", "Copernicus EMS", "UNOSAT", "HDX (CKAN)", "FEWS NET", "WFP mVAM"]
+  agency:
+    source_type: ["agency"]
+    publisher: ["*"]                     # any other agency-like source
+  media_discovery_only:
+    source_type: ["media"]
+
+conflict_rule:
+  threshold_pct: 20
+  tie_breaker: latest_as_of
+
+cutoff:
+  timezone: "Europe/Istanbul"
+  lag_days_allowed: 7

--- a/resolver/tools/precedence_engine.py
+++ b/resolver/tools/precedence_engine.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""
+precedence_engine.py — select one authoritative total per country/hazard at a cut-off.
+
+Example:
+  python resolver/tools/precedence_engine.py \
+    --facts resolver/exports/facts.csv \
+    --cutoff 2025-09-30
+
+Outputs:
+  resolver/exports/resolved.csv
+  resolver/exports/resolved.jsonl
+  resolver/exports/resolved_diagnostics.csv   # conflicts & reasons
+
+Rules implemented (from policy A2):
+  - Metric preference: in_need → else affected (configurable)
+  - Source precedence tiers with publisher/source_type mapping
+  - 7-day publication lag allowed if as_of ≤ cutoff
+  - One total only per (iso3, hazard_code)
+  - Conflict rule: if >20% apart within same tier, pick latest as_of; record alternative
+  - Always carry citation fields and definition_text
+"""
+
+import argparse, sys, json, datetime as dt
+from pathlib import Path
+from typing import List, Dict, Any
+
+try:
+    import pandas as pd
+except ImportError:
+    print("Please 'pip install pandas pyarrow pyyaml python-dateutil' to run the engine.", file=sys.stderr)
+    sys.exit(2)
+
+try:
+    import yaml
+except ImportError:
+    print("Please 'pip install pyyaml' to run the engine.", file=sys.stderr)
+    sys.exit(2)
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOLS = ROOT / "tools"
+EXPORTS = ROOT / "exports"
+CONFIG = TOOLS / "precedence_config.yml"
+
+def _load(f: Path) -> pd.DataFrame:
+    ext = f.suffix.lower()
+    if ext in (".csv", ".tsv"):
+        return pd.read_csv(f, dtype=str).fillna("")
+    elif ext == ".parquet":
+        return pd.read_parquet(f)
+    else:
+        raise SystemExit(f"Unsupported facts format: {ext}")
+
+def _load_cfg() -> Dict[str, Any]:
+    with open(CONFIG, "r", encoding="utf-8") as fp:
+        return yaml.safe_load(fp)
+
+def _to_date(s: str) -> dt.date:
+    return dt.date.fromisoformat(s)
+
+def _within_pub_lag(pub: str, cutoff: dt.date, lag_days: int) -> bool:
+    try:
+        return _to_date(pub) <= cutoff + dt.timedelta(days=lag_days)
+    except Exception:
+        return False
+
+def _assign_tier(row, mapping: Dict[str, Any], tiers: List[str]) -> int:
+    st = str(row.get("source_type",""))
+    pub = str(row.get("publisher",""))
+    pub_norm = pub.lower()
+    for idx, tier in enumerate(tiers):
+        spec = mapping.get(tier, {})
+        stypes = [x.lower() for x in spec.get("source_type",[])]
+        pubs   = [x.lower() for x in spec.get("publisher",[])]
+        ok_st = (not stypes) or (st.lower() in stypes)
+        ok_pub = (not pubs) or ("*" in pubs) or any(p in pub_norm for p in pubs)
+        if ok_st and ok_pub:
+            return idx
+    return len(tiers)  # lowest (unknown)
+
+def _pct_diff(a: float, b: float) -> float:
+    if a == 0 and b == 0:
+        return 0.0
+    denom = max(abs(a), abs(b))
+    return abs(a - b) / denom * 100.0
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--facts", required=True, help="Path to canonical facts CSV/Parquet")
+    ap.add_argument("--cutoff", required=True, help="Cut-off date YYYY-MM-DD (Europe/Istanbul at 23:59)")
+    ap.add_argument("--outdir", default=str(EXPORTS), help="Output directory")
+    args = ap.parse_args()
+
+    facts_path = Path(args.facts)
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    cfg = _load_cfg()
+    facts = _load(facts_path)
+
+    # Basic type coercions
+    for c in facts.columns:
+        if c not in ("value",):
+            facts[c] = facts[c].astype(str).fillna("")
+    # numeric
+    facts["value_num"] = pd.to_numeric(facts["value"], errors="coerce").fillna(-1)
+
+    # Filter by cutoff & lag
+    cutoff_date = dt.date.fromisoformat(args.cutoff)
+    lag_days = int(cfg["cutoff"]["lag_days_allowed"])
+
+    eligible = facts.copy()
+    # as_of must be <= cutoff
+    eligible = eligible[eligible["as_of_date"].apply(lambda x: x and x <= args.cutoff)]
+    # publication must be <= cutoff + lag
+    eligible = eligible[eligible["publication_date"].apply(lambda x: _within_pub_lag(x, cutoff_date, lag_days))]
+
+    # Assign source_tier index
+    tiers = cfg["source_precedence"]
+    eligible["source_tier"] = eligible.apply(lambda r: _assign_tier(r, cfg["source_mapping"], tiers), axis=1)
+
+    # Resolve metric per group with preference list
+    m_pref = cfg["metric_preference"]
+
+    records = []
+    diags = []
+
+    group_cols = ["iso3","hazard_code"]
+    for (iso3, hz), g in eligible.groupby(group_cols, dropna=False):
+
+        # iterate metric preference
+        chosen_metric = None
+        chosen_row = None
+
+        for metric in m_pref:
+            mg = g[g["metric"] == metric].copy()
+            if mg.empty:
+                continue
+
+            # Take best tier (lowest index)
+            best_tier = mg["source_tier"].min()
+            mg = mg[mg["source_tier"] == best_tier].copy()
+
+            # Within tier: apply conflict rule
+            mg["val"] = mg["value_num"]
+            mg = mg[mg["val"] >= 0].copy()
+            if mg.empty:
+                continue
+
+            # Sort by as_of desc, then publication_date desc
+            mg = mg.sort_values(by=["as_of_date","publication_date"], ascending=[False, False])
+
+            top = mg.iloc[0]
+            chosen_metric = metric
+            chosen_row = top
+
+            # If there is a second candidate in same tier far apart, record diagnostics
+            if len(mg) > 1:
+                second = mg.iloc[1]
+                diff = _pct_diff(float(top["val"]), float(second["val"]))
+                if diff > float(cfg["conflict_rule"]["threshold_pct"]):
+                    diags.append({
+                        "iso3": iso3,
+                        "hazard_code": hz,
+                        "metric": metric,
+                        "kept_value": top["val"],
+                        "kept_publisher": top["publisher"],
+                        "kept_source_url": top["source_url"],
+                        "alt_value": second["val"],
+                        "alt_publisher": second["publisher"],
+                        "alt_source_url": second["source_url"],
+                        "pct_diff": round(diff, 2),
+                        "note": "conflict > threshold; kept latest as_of within best tier"
+                    })
+            break  # stop after first available metric in preference list
+
+        if chosen_row is None:
+            # Nothing for preferred metrics; skip this iso3/hazard
+            continue
+
+        rec = {
+            # Keys for downstream
+            "iso3": iso3,
+            "hazard_code": hz,
+            "hazard_label": chosen_row["hazard_label"],
+            "hazard_class": chosen_row["hazard_class"],
+            "metric": chosen_metric,
+            "value": int(float(chosen_row["val"])),
+            "unit": chosen_row.get("unit","persons"),
+            "as_of_date": chosen_row["as_of_date"],
+            "publication_date": chosen_row["publication_date"],
+            "publisher": chosen_row["publisher"],
+            "source_type": chosen_row["source_type"],
+            "source_url": chosen_row["source_url"],
+            "doc_title": chosen_row["doc_title"],
+            "definition_text": chosen_row["definition_text"],
+            "precedence_tier": tiers[int(chosen_row["source_tier"])] if int(chosen_row["source_tier"]) < len(tiers) else "unknown",
+            "event_id": chosen_row["event_id"],
+            "proxy_for": chosen_row.get("proxy_for",""),
+            "confidence": chosen_row.get("confidence",""),
+        }
+        records.append(rec)
+
+    if not records:
+        print("No eligible records found at this cutoff.", file=sys.stderr)
+
+    # Write outputs
+    resolved = pd.DataFrame(records)
+    csv_out = outdir / "resolved.csv"
+    jl_out  = outdir / "resolved.jsonl"
+    diag_out = outdir / "resolved_diagnostics.csv"
+
+    if len(resolved):
+        resolved.to_csv(csv_out, index=False)
+        with open(jl_out, "w", encoding="utf-8") as f:
+            for _, r in resolved.iterrows():
+                f.write(json.dumps({k: (None if pd.isna(v) else v) for k, v in r.items()}, ensure_ascii=False) + "\n")
+    pd.DataFrame(diags).to_csv(diag_out, index=False)
+
+    print("✅ precedence engine complete")
+    print(f" - {csv_out}")
+    print(f" - {jl_out}")
+    print(f" - {diag_out}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add precedence policy configuration and precedence engine tool to select authoritative totals at a cutoff
- document how to run the new resolver precedence workflow and provide sample inputs/expected outputs for smoke testing

## Testing
- python resolver/tools/precedence_engine.py --facts resolver/exports/facts_minimal.csv --cutoff 2025-09-30 --outdir resolver/exports/test_run

------
https://chatgpt.com/codex/tasks/task_e_68dbce51d5ec832cac781a1b17ff7807