### PR TITLE
[resolver] Add review queue tooling

### DIFF
--- a/resolver/review/README.md
+++ b/resolver/review/README.md
@@ -1,0 +1,26 @@
+# Review Queue
+
+Human-in-the-loop checks for edge cases before we publish/grade.
+
+## What gets flagged
+- Conflicts > 20% (from `exports/resolved_diagnostics.csv`)
+- Low confidence (`confidence = low`)
+- Media-sourced rows when `metric = in_need`
+- Proxy usage (`proxy_for = PIN`)
+- Date anomalies (as_of > publication or publication > today)
+- Tier risk: selected `precedence_tier` is not top tiers
+
+## Files
+- `review_queue.csv` — you edit this file:
+  - `analyst_decision` ∈ `keep|override|drop`
+  - if `override`, fill `override_value`, `override_source_url` (opt), `override_notes` (opt)
+
+## Workflow
+```bash
+python resolver/review/make_review_queue.py
+# edit resolver/review/review_queue.csv
+python resolver/review/apply_review_overrides.py \
+  --resolved resolver/exports/resolved.csv \
+  --decisions resolver/review/review_queue.csv \
+  --out resolver/exports/resolved_reviewed.csv
+```

--- a/resolver/review/apply_review_overrides.py
+++ b/resolver/review/apply_review_overrides.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+import argparse, sys
+from pathlib import Path
+
+try:
+    import pandas as pd
+except ImportError:
+    print("Please 'pip install pandas pyarrow' to run the override applier.", file=sys.stderr)
+    sys.exit(2)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--resolved", required=True)
+    ap.add_argument("--decisions", required=True)
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    resolved = pd.read_csv(args.resolved, dtype=str).fillna("")
+    decisions = pd.read_csv(args.decisions, dtype=str).fillna("")
+
+    for df in (resolved, decisions):
+        df["key"] = (
+            df["iso3"].astype(str)
+            + "|"
+            + df["hazard_code"].astype(str)
+            + "|"
+            + df["metric"].astype(str)
+        )
+
+    dec = decisions[
+        ["key", "analyst_decision", "override_value", "override_source_url", "override_notes"]
+    ].copy()
+
+    merged = resolved.merge(dec, on="key", how="left", suffixes=("", "_dec"))
+
+    out_rows = []
+    status = []
+
+    for _, r in merged.iterrows():
+        action = (r.get("analyst_decision", "") or "").strip().lower()
+        row = r.copy()
+
+        if action == "drop":
+            status.append("dropped")
+            continue
+
+        elif action == "override":
+            val = (r.get("override_value", "") or "").strip()
+            try:
+                vnum = int(float(val))
+                row["value"] = str(vnum)
+                url = (r.get("override_source_url", "") or "").strip()
+                if url:
+                    row["source_url"] = url
+                notes = (r.get("override_notes", "") or "").strip()
+                if notes:
+                    row["definition_text"] = (
+                        row.get("definition_text", "") + f" [OVERRIDE NOTE: {notes}]"
+                    ).strip()
+                status.append("overridden")
+            except Exception:
+                status.append("no_decision")
+
+        elif action == "keep":
+            status.append("kept")
+
+        else:
+            status.append("no_decision")
+
+        out_rows.append(row)
+
+    out = pd.DataFrame(out_rows).drop(columns=["key"], errors="ignore")
+    out["review_status"] = status[: len(out)]
+
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    out.to_csv(args.out, index=False)
+    print(f"✅ overrides applied → {args.out} (rows: {len(out)})")
+
+
+if __name__ == "__main__":
+    main()

--- a/resolver/review/make_review_queue.py
+++ b/resolver/review/make_review_queue.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+import sys
+import datetime as dt
+from pathlib import Path
+
+try:
+    import pandas as pd
+except ImportError:
+    print("Please 'pip install pandas pyarrow' to run the review builder.", file=sys.stderr)
+    sys.exit(2)
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPORTS = ROOT / "exports"
+REVIEW = ROOT / "review"
+
+RESOLVED_CSV = EXPORTS / "resolved.csv"
+DIAG_CSV = EXPORTS / "resolved_diagnostics.csv"
+QUEUE_CSV = REVIEW / "review_queue.csv"
+DECISIONS_EX = REVIEW / "decisions_example.csv"
+
+TOP_TIERS = {"inter_agency_plan", "ifrc_or_gov_sitrep", "un_cluster_snapshot"}
+
+
+def _is_date(s: str) -> bool:
+    try:
+        dt.date.fromisoformat(s)
+        return True
+    except Exception:
+        return False
+
+
+def load_or_empty(path: Path) -> pd.DataFrame:
+    if not path.exists():
+        return pd.DataFrame()
+    return pd.read_csv(path, dtype=str).fillna("")
+
+
+def main():
+    if not RESOLVED_CSV.exists():
+        print(f"Missing {RESOLVED_CSV}. Run precedence engine first.", file=sys.stderr)
+        sys.exit(2)
+
+    resolved = pd.read_csv(RESOLVED_CSV, dtype=str).fillna("")
+    diags = load_or_empty(DIAG_CSV)
+
+    resolved["key"] = (
+        resolved["iso3"].astype(str)
+        + "|"
+        + resolved["hazard_code"].astype(str)
+        + "|"
+        + resolved["metric"].astype(str)
+    )
+    if not diags.empty:
+        diags["key"] = (
+            diags["iso3"].astype(str)
+            + "|"
+            + diags["hazard_code"].astype(str)
+            + "|"
+            + diags["metric"].astype(str)
+        )
+        conflict_keys = set(diags["key"])
+    else:
+        conflict_keys = set()
+
+    today = dt.date.today().isoformat()
+
+    def flags(r):
+        a = r.get("as_of_date", "")
+        p = r.get("publication_date", "")
+        date_anomaly = "0"
+        if _is_date(a) and _is_date(p):
+            if a > p or p > today:
+                date_anomaly = "1"
+        else:
+            date_anomaly = "1"
+
+        tier = r.get("precedence_tier", "")
+        f = {
+            "conflict": "1" if r["key"] in conflict_keys else "0",
+            "low_confidence": "1" if r.get("confidence", "").lower() == "low" else "0",
+            "media_in_need": "1"
+            if (r.get("source_type", "") == "media" and r.get("metric", "") == "in_need")
+            else "0",
+            "proxy_used": "1" if str(r.get("proxy_for", "")).upper() == "PIN" else "0",
+            "tier_risk": "1" if tier not in TOP_TIERS else "0",
+            "date_anomaly": date_anomaly,
+        }
+        f["needs_review"] = "1" if any(v == "1" for v in f.values()) else "0"
+        return pd.Series(f)
+
+    flagged = resolved.copy()
+    flagged = pd.concat([flagged, flagged.apply(flags, axis=1)], axis=1)
+
+    for col in [
+        "analyst_decision",
+        "override_value",
+        "override_source_url",
+        "override_notes",
+    ]:
+        flagged[col] = ""
+
+    REVIEW.mkdir(parents=True, exist_ok=True)
+    flagged.to_csv(QUEUE_CSV, index=False)
+    flagged.head(2).to_csv(DECISIONS_EX, index=False)
+
+    print("✅ review queue written:")
+    print(f" - {QUEUE_CSV}")
+    print(f" - {DECISIONS_EX} (example)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add human-in-the-loop review documentation under `resolver/review`
- build the review queue generator that flags rows needing analyst attention
- add an override applier that merges analyst decisions into the resolved export

## Testing
- not run (scripts only)


------
https://chatgpt.com/codex/tasks/task_e_68dbf7191510832ca83e3f2906ce0c56