### PR TITLE
Handle missing seen_guard module when locking questions

### DIFF
--- a/spagbot/cli.py
+++ b/spagbot/cli.py
@@ -1253,15 +1253,21 @@ async def run_one_question(
     q = _as_dict(post.get("question"))
     question_id = int(q.get("id") or post.get("id") or post.get("post_id") or 0)
 
+    sg_available = False
+    try:
+        sg_available = seen_guard is not None and hasattr(seen_guard, "lock")
+    except (NameError, AttributeError):
+        sg_available = False
+
     seen_guard_state: Dict[str, Any] = {
-        "enabled": bool(seen_guard),
+        "enabled": sg_available,
         "lock_acquired": None,
         "lock_error": "",
     }
 
     lock_stack = ExitStack()
     try:
-        if seen_guard:
+        if sg_available:
             try:
                 acquired = lock_stack.enter_context(seen_guard.lock(question_id))
                 seen_guard_state["lock_acquired"] = bool(acquired)


### PR DESCRIPTION
## Summary
- guard run_one_question against missing or partial seen_guard modules when acquiring locks
- reuse the same availability check for state reporting and lock acquisition

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc0b8e938c832c8f0f4a8528aa1619