### PR TITLE
Improve error diagnostics in run_one_question

### DIFF
--- a/spagbot/cli.py
+++ b/spagbot/cli.py
@@ -1228,6 +1228,12 @@ async def _run_one_question_body(
     
     
     except Exception as _e:
+        import traceback
+
+        print("[error] Exception in _run_one_question_body:")
+        print(f"[error] {type(_e).__name__}: {str(_e)}")
+        print("[error] Traceback:")
+        traceback.print_exc()
         _post_t = type(_post_original).__name__
         try:
             _q_t = type(q).__name__


### PR DESCRIPTION
## Summary
- add explicit traceback printing in `_run_one_question_body`'s exception handler
- preserve existing RuntimeError wrapping while exposing the underlying exception details

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc0d2ce7f0832ca9c6a43bc1e5266a