### PR TITLE
feat: publish resolver CI outputs to repo

### DIFF
--- a/.github/workflows/resolver-ci.yml
+++ b/.github/workflows/resolver-ci.yml
@@ -1,0 +1,180 @@
+name: resolver-ci
+
+on:
+  pull_request:
+    paths:
+      - "resolver/**"
+      - ".github/workflows/resolver-ci.yml"
+  workflow_dispatch: {}
+  schedule:
+    # Daily at 20:10 UTC ≈ 23:10 Europe/Istanbul
+    - cron: "10 20 * * *"
+
+permissions:
+  contents: write   # <-- needed to push commits
+
+concurrency:
+  group: resolver-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pr-checks:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pandas pyarrow pyyaml python-dateutil
+
+      - name: Generate ingestion stubs (no network)
+        run: |
+          python resolver/ingestion/run_all_stubs.py
+
+      - name: Export facts
+        run: |
+          python resolver/tools/export_facts.py --in resolver/staging --out resolver/exports
+
+      - name: Validate facts
+        run: |
+          python resolver/tools/validate_facts.py --facts resolver/exports/facts.csv
+
+      - name: Precedence at provisional cutoff (end of current month)
+        run: |
+          LAST=$(date -u -d "$(date -u +%Y-%m-01) +1 month -1 day" +%Y-%m-%d)
+          python resolver/tools/precedence_engine.py --facts resolver/exports/facts.csv --cutoff $LAST
+
+      - name: Build review queue
+        run: |
+          python resolver/review/make_review_queue.py
+
+      - name: Stage repo state for this PR
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          python resolver/tools/write_repo_state.py --mode pr --id "$PR_NUMBER"
+
+      - name: Commit & push PR state to branch
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add resolver/state/pr/"$PR_NUMBER"/exports/*.csv || true
+          git add resolver/state/pr/"$PR_NUMBER"/exports/*.jsonl || true
+          git add resolver/state/pr/"$PR_NUMBER"/review/review_queue.csv || true
+          if ! git diff --cached --quiet; then
+            git commit -m "chore(resolver): PR state for #$PR_NUMBER [skip ci]"
+            git push origin HEAD:${GITHUB_REF##refs/heads/}
+          else
+            echo "No changes to commit."
+          fi
+
+  nightly:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pandas pyarrow pyyaml python-dateutil
+
+      - name: Generate ingestion stubs (no network)
+        run: |
+          python resolver/ingestion/run_all_stubs.py
+
+      - name: Export facts
+        run: |
+          python resolver/tools/export_facts.py --in resolver/staging --out resolver/exports
+
+      - name: Validate facts
+        run: |
+          python resolver/tools/validate_facts.py --facts resolver/exports/facts.csv
+
+      - name: Precedence at Istanbul date
+        run: |
+          python resolver/tools/schedule_gate.py > gate.json
+          CUT=$(python - << 'PY'
+import json
+print(json.load(open('gate.json'))['istanbul_today'])
+PY
+)
+          python resolver/tools/precedence_engine.py --facts resolver/exports/facts.csv --cutoff $CUT
+
+      - name: Build review queue
+        run: |
+          python resolver/review/make_review_queue.py
+
+      - name: Freeze snapshot if last Istanbul day
+        id: freeze
+        run: |
+          python resolver/tools/schedule_gate.py > gate.json
+          echo "gate=$(cat gate.json)" >> $GITHUB_OUTPUT
+          IS_LAST=$(python - << 'PY'
+import json
+print("true" if json.load(open('gate.json'))['is_last_day_istanbul'] else "false")
+PY
+)
+          if [ "$IS_LAST" = "true" ]; then
+            YM=$(python - << 'PY'
+import json
+print(json.load(open('gate.json'))['istanbul_today'][:7])
+PY
+)
+            python resolver/tools/freeze_snapshot.py --facts resolver/exports/facts.csv --month "$YM" --overwrite
+            echo "ym=$YM" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Stage repo state for nightly
+        run: |
+          D=$(date -u +%Y-%m-%d)
+          python resolver/tools/write_repo_state.py --mode daily --id "$D"
+
+      - name: Commit & push nightly state (and snapshot if created)
+        env:
+          YM: ${{ steps.freeze.outputs.ym }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Nightly state
+          git add resolver/state/daily/*/exports/*.csv || true
+          git add resolver/state/daily/*/exports/*.jsonl || true
+          git add resolver/state/daily/*/review/review_queue.csv || true
+
+          # Snapshot (if created this run)
+          if [ -n "$YM" ]; then
+            git add resolver/snapshots/"$YM"/facts.parquet || true
+            git add resolver/snapshots/"$YM"/manifest.json || true
+          fi
+
+          if ! git diff --cached --quiet; then
+            MSG="chore(resolver): nightly state"
+            if [ -n "$YM" ]; then MSG="$MSG + snapshot $YM"; fi
+            git commit -m "$MSG [skip ci]"
+            git push origin HEAD:${GITHUB_REF##refs/heads/}
+          else
+            echo "No changes to commit."
+          fi

--- a/resolver/README.md
+++ b/resolver/README.md
@@ -78,6 +78,17 @@ resolver/exports/facts.csv (+ optional Parquet)
 resolver/snapshots/YYYY-MM/{facts.parquet,manifest.json}
 
 
+## Remote-first state layout
+
+When CI runs, it commits outputs into the repo so you can consume them directly:
+
+- **PR state:** `resolver/state/pr/<PR_NUMBER>/...`
+- **Nightly state:** `resolver/state/daily/<YYYY-MM-DD>/...`
+- **Monthly snapshots (authoritative for grading):** `resolver/snapshots/<YYYY-MM>/...`
+
+This means the resolver can run from the remote alone (clone/pull → read files).
+
+
 ## Resolve at a cutoff (precedence engine)
 
 Select one authoritative total per `(iso3, hazard_code)` applying A2 policy:

--- a/resolver/ci/README.md
+++ b/resolver/ci/README.md
@@ -1,0 +1,17 @@
+# Resolver CI
+
+This directory documents the resolver continuous integration workflows.
+
+## Remote-first commits
+
+CI now commits outputs directly to the repo:
+
+- **PR runs:** `resolver/state/pr/<PR_NUMBER>/...`
+- **Nightly runs:** `resolver/state/daily/<YYYY-MM-DD>/...`
+- **Month-end snapshot:** `resolver/snapshots/<YYYY-MM>/{facts.parquet,manifest.json}`
+
+Commits are authored by `github-actions[bot]` and include `[skip ci]` to avoid recursive runs.
+
+### Forked PRs
+For security, GitHub disables `GITHUB_TOKEN` write permissions on PRs from forks by default.  
+If you expect external contributors, keep the old “upload artifact” step as a fallback or switch to `pull_request_target` with careful path filters and review.

--- a/resolver/tools/write_repo_state.py
+++ b/resolver/tools/write_repo_state.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""
+write_repo_state.py — copy current run outputs into repo paths for committing.
+
+Usage examples:
+  # PR run:
+  python resolver/tools/write_repo_state.py --mode pr --id 123
+
+  # Nightly (non-PR):
+  python resolver/tools/write_repo_state.py --mode daily --id 2025-09-30
+
+This script copies:
+- exports/facts.csv, exports/resolved.csv, exports/resolved_diagnostics.csv
+- review/review_queue.csv
+- snapshots/YYYY-MM/facts.parquet + manifest.json (if exist)
+
+To:
+- PR:     resolver/state/pr/<PR_NUMBER>/{exports/*,review/*}
+- Daily:  resolver/state/daily/<YYYY-MM-DD>/{exports/*,review/*}
+- Snap:   resolver/snapshots/<YYYY-MM>/*  (if present)
+"""
+
+import argparse, shutil
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPORTS = ROOT / "exports"
+REVIEW  = ROOT / "review"
+SNAPS   = ROOT / "snapshots"
+STATE   = ROOT / "state"
+
+def safe_copy(src: Path, dst: Path):
+    if src.exists():
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst)
+
+def copy_dir(src_dir: Path, dst_dir: Path, patterns: list[str]):
+    dst_dir.mkdir(parents=True, exist_ok=True)
+    for ptn in patterns:
+        for p in src_dir.glob(ptn):
+            if p.is_file():
+                shutil.copy2(p, dst_dir / p.name)
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--mode", required=True, choices=["pr","daily"])
+    ap.add_argument("--id", required=True, help="PR number for mode=pr, or YYYY-MM-DD for mode=daily")
+    args = ap.parse_args()
+
+    if args.mode == "pr":
+        base = STATE / "pr" / str(args.id)
+    else:
+        base = STATE / "daily" / str(args.id)
+
+    # Copy exports files
+    copy_dir(EXPORTS, base / "exports", ["facts.csv","resolved.csv","resolved.jsonl","resolved_diagnostics.csv"])
+
+    # Copy review file
+    safe_copy(REVIEW / "review_queue.csv", base / "review" / "review_queue.csv")
+
+    # Copy any snapshot written in this run (pattern snapshots/*/*)
+    if SNAPS.exists():
+        for ym_dir in SNAPS.glob("[0-9][0-9][0-9][0-9]-[0-9][0-9]"):
+            f = ym_dir / "facts.parquet"
+            m = ym_dir / "manifest.json"
+            if f.exists() and m.exists():
+                # We copy snapshots in-place (they already live under resolver/snapshots/),
+                # so no duplicate under state/. Leaving them where they are is enough.
+                pass
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a helper to copy resolver exports/review data into commit-friendly locations
- update the resolver CI workflow to push PR and nightly results back to the repository
- document the remote-first layout for CI outputs and snapshots

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dcfe1e35ec832c92cd48311b64bfa0