### PR TITLE
Add resolver data contract pytest suite and CI integration

### DIFF
--- a/.github/workflows/resolver-ci.yml
+++ b/.github/workflows/resolver-ci.yml
@@ -58,6 +58,11 @@ jobs:
         run: |
           python resolver/review/make_review_queue.py
 
+      - name: Run data-contract tests (pytest)
+        run: |
+          pip install pytest
+          pytest resolver/tests -q
+
       - name: Stage repo state for this PR
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -125,6 +130,11 @@ PY
       - name: Build review queue
         run: |
           python resolver/review/make_review_queue.py
+
+      - name: Run data-contract tests (pytest)
+        run: |
+          pip install pytest
+          pytest resolver/tests -q
 
       - name: Freeze snapshot if last Istanbul day
         id: freeze

--- a/resolver/tests/README.md
+++ b/resolver/tests/README.md
@@ -1,0 +1,19 @@
+# Resolver — Data Contract Tests
+
+These tests enforce basic contracts across:
+- Registries (`resolver/data/*.csv`)
+- Exports (`resolver/exports/facts.csv`)
+- Resolved outputs (`resolver/exports/resolved*.{csv,jsonl}`)
+- Review queue (`resolver/review/review_queue.csv`)
+- Snapshots (`resolver/snapshots/YYYY-MM/facts.parquet`), if present
+- Remote-first state files under `resolver/state/**/exports/*.csv`
+
+## Run locally
+
+```bash
+pip install pytest pandas pyarrow pyyaml python-dateutil
+pytest resolver/tests -q
+```
+
+Tests will skip gracefully if an expected file isn't present (e.g., snapshots),
+but will fail if a file exists and violates the contract.

--- a/resolver/tests/pytest.ini
+++ b/resolver/tests/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+addopts = -q
+python_files = test_*.py
+filterwarnings =
+    ignore::UserWarning

--- a/resolver/tests/test_exports_contract.py
+++ b/resolver/tests/test_exports_contract.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+import math, datetime as dt
+import pandas as pd
+from resolver.tests.test_utils import (
+    load_schema, load_countries, load_shocks, read_csv,
+    discover_export_files, today_iso, require_columns
+)
+
+def _is_iso_date(s: str) -> bool:
+    try:
+        dt.date.fromisoformat(s); return True
+    except Exception:
+        return False
+
+def _num_ok(x: str) -> bool:
+    try:
+        return float(x) >= 0
+    except Exception:
+        return False
+
+def test_exports_facts_contract_if_present():
+    schema = load_schema()
+    req = set(schema["required"])
+    enum_metric = set(schema["enums"]["metric"])
+    enum_unit = set(schema["enums"]["unit"])
+    countries = load_countries()
+    shocks = load_shocks()
+    cset = set(countries["iso3"])
+    sset = set(shocks["hazard_code"])
+
+    # prefer current canonical facts
+    paths = [p for p in discover_export_files() if p.name == "facts.csv" and "state" not in str(p)]
+    if not paths:
+        # skip if no exports/facts.csv yet
+        return
+
+    df = read_csv(paths[0])
+
+    # columns present
+    missing = req - set(df.columns)
+    assert not missing, f"Missing required columns: {missing}"
+
+    # registry membership
+    assert df["iso3"].isin(cset).all(), "Some iso3 not in countries registry"
+    assert df["hazard_code"].isin(sset).all(), "Some hazard_code not in shocks registry"
+
+    # labels/classes match the shocks registry rows
+    reg = shocks.set_index("hazard_code")
+    bad_label = []
+    bad_class = []
+    for _, r in df.iterrows():
+        code = r["hazard_code"]
+        if code in reg.index:
+            if r["hazard_label"] != reg.loc[code, "hazard_label"]:
+                bad_label.append(code)
+            if r["hazard_class"] != reg.loc[code, "hazard_class"]:
+                bad_class.append(code)
+    assert not bad_label, f"hazard_label mismatch for codes: {set(bad_label)}"
+    assert not bad_class, f"hazard_class mismatch for codes: {set(bad_class)}"
+
+    # metric & unit enums
+    assert df["metric"].isin(enum_metric).all()
+    assert df["unit"].isin(enum_unit).all()
+
+    # numeric values >= 0
+    assert df["value"].map(_num_ok).all(), "Non-numeric or negative values present"
+
+    # date sanity
+    assert df["as_of_date"].map(_is_iso_date).all()
+    assert df["publication_date"].map(_is_iso_date).all()
+    assert (df["as_of_date"] <= df["publication_date"]).all()
+    assert (df["publication_date"] <= today_iso()).all()
+
+    # governance rules
+    media_in_need = df[(df["source_type"] == "media") & (df["metric"] == "in_need")]
+    assert media_in_need.empty, "Policy: media cannot be the source for in_need"
+
+    cases_wrong_unit = df[(df["metric"] == "cases") & (df["unit"] != "persons_cases")]
+    assert cases_wrong_unit.empty, "Policy: cases must use unit=persons_cases"
+
+def test_remote_first_state_exports_are_valid_if_present():
+    # Validate any committed state exports CSVs (PR or daily). Skip gracefully if none.
+    schema = load_schema()
+    req = set(schema["required"])
+    enum_metric = set(schema["enums"]["metric"])
+    enum_unit = set(schema["enums"]["unit"])
+    countries = load_countries()
+    shocks = load_shocks()
+    cset = set(countries["iso3"]); sset = set(shocks["hazard_code"])
+
+    paths = [p for p in discover_export_files() if p.name == "facts.csv" and "state" in str(p)]
+    if not paths:
+        return
+
+    for p in paths:
+        df = read_csv(p)
+        missing = req - set(df.columns)
+        assert not missing, f"{p}: missing columns {missing}"
+        assert df["iso3"].isin(cset).all(), f"{p}: iso3 not in registry"
+        assert df["hazard_code"].isin(sset).all(), f"{p}: hazard_code not in registry"
+        assert df["metric"].isin(enum_metric).all(), f"{p}: metric enum"
+        assert df["unit"].isin(enum_unit).all(), f"{p}: unit enum"

--- a/resolver/tests/test_registries.py
+++ b/resolver/tests/test_registries.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+from pathlib import Path
+import re
+from resolver.tests.test_utils import load_countries, load_shocks
+
+def test_countries_registry_has_iso3_and_names():
+    c = load_countries()
+    assert {"country_name", "iso3"}.issubset(set(c.columns))
+    assert not c["iso3"].isnull().any()
+    assert not c["country_name"].isnull().any()
+    assert c["iso3"].str.len().eq(3).all()
+
+def test_shocks_registry_columns_and_scope():
+    s = load_shocks()
+    assert {"hazard_code","hazard_label","hazard_class"}.issubset(set(s.columns))
+    assert not s.empty
+    # scope: no earthquakes (we don't forecast them here)
+    labels = s["hazard_label"].str.lower().tolist()
+    assert not any("earthquake" in x for x in labels)
+    # classes must be in allowed set
+    allowed = {"natural","human-induced","epidemic"}
+    assert set(s["hazard_class"]).issubset(allowed)

--- a/resolver/tests/test_resolved_and_review.py
+++ b/resolver/tests/test_resolved_and_review.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+import json
+from pathlib import Path
+import pandas as pd
+from resolver.tests.test_utils import EXPORTS, REVIEW, read_csv
+
+REQUIRED_RESOLVED = {
+    "iso3","hazard_code","hazard_label","hazard_class",
+    "metric","value","unit","as_of_date","publication_date",
+    "publisher","source_type","source_url","doc_title",
+    "definition_text","event_id"
+}
+
+def test_resolved_shapes_if_present():
+    csv = EXPORTS / "resolved.csv"
+    if not csv.exists():
+        return
+    df = read_csv(csv)
+    missing = REQUIRED_RESOLVED - set(df.columns)
+    assert not missing, f"resolved.csv missing {missing}"
+    # value numeric
+    assert pd.to_numeric(df["value"], errors="coerce").notna().all()
+
+def test_resolved_jsonl_if_present():
+    jl = EXPORTS / "resolved.jsonl"
+    if not jl.exists():
+        return
+    # ensure it parses line-by-line JSON and has key fields
+    with open(jl, "r", encoding="utf-8") as f:
+        for i, line in enumerate(f, 1):
+            obj = json.loads(line)
+            assert "iso3" in obj and "hazard_code" in obj and "value" in obj, f"line {i} missing essentials"
+
+def test_review_queue_if_present():
+    rq = REVIEW / "review_queue.csv"
+    if not rq.exists():
+        return
+    df = read_csv(rq)
+    expected_cols = {
+        "iso3","hazard_code","metric","value","precedence_tier",
+        "conflict","low_confidence","media_in_need","proxy_used","tier_risk","date_anomaly","needs_review",
+        "analyst_decision","override_value","override_source_url","override_notes"
+    }
+    missing = expected_cols - set(df.columns)
+    assert not missing, f"review_queue.csv missing {missing}"

--- a/resolver/tests/test_snapshots.py
+++ b/resolver/tests/test_snapshots.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+from pathlib import Path
+from resolver.tests.test_utils import SNAPS, read_parquet
+
+def test_any_snapshot_parquet_reads_and_has_core_columns():
+    if not SNAPS.exists():
+        return
+    # take any facts.parquet present
+    paths = list(SNAPS.glob("*/facts.parquet"))
+    if not paths:
+        return
+    df = read_parquet(paths[0])
+    core = {"iso3","hazard_code","metric","value","as_of_date","publication_date"}
+    assert core.issubset(set(df.columns))

--- a/resolver/tests/test_utils.py
+++ b/resolver/tests/test_utils.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+import json, os, glob, datetime as dt
+from pathlib import Path
+from typing import List, Dict, Any, Iterable
+
+import pandas as pd
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA = ROOT / "data"
+TOOLS = ROOT / "tools"
+EXPORTS = ROOT / "exports"
+REVIEW  = ROOT / "review"
+SNAPS   = ROOT / "snapshots"
+STATE   = ROOT / "state"
+
+SCHEMA_YML = TOOLS / "schema.yml"
+COUNTRIES_CSV = DATA / "countries.csv"
+SHOCKS_CSV = DATA / "shocks.csv"
+
+def today_iso() -> str:
+    return dt.date.today().isoformat()
+
+def load_schema() -> Dict[str, Any]:
+    with open(SCHEMA_YML, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+def load_countries() -> pd.DataFrame:
+    return pd.read_csv(COUNTRIES_CSV, dtype=str).fillna("")
+
+def load_shocks() -> pd.DataFrame:
+    return pd.read_csv(SHOCKS_CSV, dtype=str).fillna("")
+
+def read_csv(path: Path) -> pd.DataFrame:
+    return pd.read_csv(path, dtype=str).fillna("")
+
+def read_parquet(path: Path) -> pd.DataFrame:
+    return pd.read_parquet(path)
+
+def discover_export_files() -> List[Path]:
+    files: List[Path] = []
+    if EXPORTS.exists():
+        files += [p for p in [EXPORTS / "facts.csv"] if p.exists()]
+        files += list(EXPORTS.glob("resolved*.csv"))
+    # remote-first state: include any committed exports csvs
+    if STATE.exists():
+        files += list(STATE.glob("pr/*/exports/*.csv"))
+        files += list(STATE.glob("daily/*/exports/*.csv"))
+    # de-duplicate
+    uniq = []
+    seen = set()
+    for f in files:
+        s = str(f)
+        if s not in seen:
+            uniq.append(f)
+            seen.add(s)
+    return uniq
+
+def require_columns(df: pd.DataFrame, cols: Iterable[str]) -> List[str]:
+    return [c for c in cols if c not in df.columns]


### PR DESCRIPTION
## Summary
- add pytest-based data contract tests covering registries, exports, resolved outputs, review queue, and snapshots
- document the resolver test suite and configure pytest defaults
- run the resolver data-contract tests inside the resolver CI workflow

## Testing
- pytest resolver/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68dd03594d28832caf2d1dfab11e49d3