### PR TITLE
feat: add ReliefWeb API connector to resolver ingestion

### DIFF
--- a/resolver/ingestion/README.md
+++ b/resolver/ingestion/README.md
@@ -1,31 +1,33 @@
 # Ingestion (Scaffold)
 
-This folder holds **stub connectors** that generate small **staging CSVs** (no external calls yet).
-They allow you to test the full pipeline now:
+This folder holds **connectors** that generate **staging CSVs**. Most are currently stubs
+(no external calls yet) so you can exercise the pipeline end-to-end. ReliefWeb is now a
+real API client.
 
 **Stubs → Export → Validate → Freeze**
 
 Later (Epic C) we will replace stubs with real API/scraper clients.
 
-## Sources covered (stubs)
-- ReliefWeb (`reliefweb_stub.py`)
-- IFRC GO (`ifrc_go_stub.py`)
-- UNHCR ODP (`unhcr_stub.py`)
-- IOM DTM (`dtm_stub.py`)
-- WHO Emergencies (`who_stub.py`)
-- IPC (`ipc_stub.py`)
-- EM-DAT (`emdat_stub.py`)
-- GDACS (`gdacs_stub.py`)
-- Copernicus EMS (`copernicus_stub.py`)
-- UNOSAT (`unosat_stub.py`)
-- HDX (CKAN) (`hdx_stub.py`)
-- ACLED (`acled_stub.py`)
-- UCDP (`ucdp_stub.py`)
-- FEWS NET (`fews_stub.py`)
-- WFP mVAM (`wfp_mvam_stub.py`)
-- Gov NDMA (`gov_ndma_stub.py`)
+## Sources covered
 
-Each stub:
+- ReliefWeb — **API connector** (`reliefweb_client.py`) → `staging/reliefweb.csv`
+- IFRC GO — stub (`ifrc_go_stub.py`)
+- UNHCR ODP — stub (`unhcr_stub.py`)
+- IOM DTM — stub (`dtm_stub.py`)
+- WHO Emergencies — stub (`who_stub.py`)
+- IPC — stub (`ipc_stub.py`)
+- EM-DAT — stub (`emdat_stub.py`)
+- GDACS — stub (`gdacs_stub.py`)
+- Copernicus EMS — stub (`copernicus_stub.py`)
+- UNOSAT — stub (`unosat_stub.py`)
+- HDX (CKAN) — stub (`hdx_stub.py`)
+- ACLED — stub (`acled_stub.py`)
+- UCDP — stub (`ucdp_stub.py`)
+- FEWS NET — stub (`fews_stub.py`)
+- WFP mVAM — stub (`wfp_mvam_stub.py`)
+- Gov NDMA — stub (`gov_ndma_stub.py`)
+
+Each connector:
 - Reads `resolver/data/countries.csv` and `resolver/data/shocks.csv`
 - Produces `resolver/staging/<source>.csv` using the exporter’s expected columns
 
@@ -44,7 +46,16 @@ python resolver/tools/freeze_snapshot.py --facts resolver/exports/facts.csv --mo
 
 Notes
 
-Stubs are deterministic samples for now (no network). Replace their internal make_rows() with real pulls in Epic C.
+Stubs are deterministic samples for now (no network). Replace their internal `make_rows()`
+with real pulls in Epic C.
+
+### ReliefWeb specifics
+
+- Window: last `window_days` (configurable in `ingestion/config/reliefweb.yml`)
+- Filters: English language; report/appeal/update formats
+- Hazards: keyword mapping (conservative)
+- Metrics: PIN preferred (if phrase found), else PA; PHE allows `cases` (unit = persons_cases)
+- No PDF parsing in v1; title/summary only
 
 Hazards must match resolver/data/shocks.csv (e.g., FL, DR, TC, HW, ACO, ACE, ACC, DI, CU, EC, PHE).
 

--- a/resolver/ingestion/checklist.yml
+++ b/resolver/ingestion/checklist.yml
@@ -4,7 +4,7 @@ sources:
     cadence: high
     output: resolver/staging/reliefweb.csv
     owner: ingestion
-    status: stub
+    status: api
   ifrc_go:
     cadence: high
     output: resolver/staging/ifrc_go.csv

--- a/resolver/ingestion/config/reliefweb.yml
+++ b/resolver/ingestion/config/reliefweb.yml
@@ -1,0 +1,36 @@
+appname: "spagbot-resolver"
+user_agent: "spagbot-resolver/1.0 (github.com/kwyjad/Spagbot_metac-bot)"
+base_url: "https://api.reliefweb.int/v1/reports"
+window_days: 45
+page_size: 100
+
+source_type_map:
+  report: "sitrep"
+  appeal: "appeal"
+  update: "sitrep"
+
+hazard_keywords:
+  FL: ["flood", "flash flood", "river flooding", "inundation"]
+  DR: ["drought", "rainfall deficit", "dry spell", "water shortage"]
+  TC: ["tropical cyclone", "typhoon", "hurricane", "cyclone"]
+  HW: ["heat wave", "heatwave", "extreme heat", "high temperatures"]
+  ACO: ["outbreak of fighting", "hostilities broke out"]
+  ACE: ["escalation", "intensified clashes", "surge in fighting", "offensive launched"]
+  ACC: ["ceasefire", "cessation of hostilities", "peace agreement"]
+  DI: ["influx", "cross-border displacement", "refugee influx"]
+  CU: ["protest", "civil unrest", "demonstration", "riots"]
+  EC: ["economic crisis", "inflation", "price shock", "currency depreciation"]
+  PHE: ["cholera", "measles", "dengue", "ebola", "outbreak", "epidemic", "pandemic"]
+
+metric_patterns:
+  - metric: "in_need"
+    unit: "persons"
+    patterns: ["people in need", "in need of assistance", "pin"]
+  - metric: "affected"
+    unit: "persons"
+    patterns: ["people affected", "affected people", "population affected"]
+  - metric: "cases"
+    unit: "persons_cases"
+    patterns: ["cases", "confirmed cases", "suspected cases"]
+
+iso3_exclude: []

--- a/resolver/ingestion/reliefweb_client.py
+++ b/resolver/ingestion/reliefweb_client.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""
+ReliefWeb API → staging/reliefweb.csv
+
+- Queries recent reports (last N days) with basic filters
+- Paginates with retries and backoff
+- Maps to (iso3, hazard_code) via keyword heuristics
+- Extracts PIN/PA (or cases) from title/summary using regex
+- Writes canonical staging CSV expected by our exporter/validator
+
+Usage:
+  python resolver/ingestion/reliefweb_client.py
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import re
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import pandas as pd
+import requests
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA = ROOT / "data"
+STAGING = ROOT / "staging"
+CONFIG = ROOT / "ingestion" / "config" / "reliefweb.yml"
+
+COUNTRIES = DATA / "countries.csv"
+SHOCKS = DATA / "shocks.csv"
+
+# Canonical output columns
+COLUMNS = [
+    "event_id",
+    "country_name",
+    "iso3",
+    "hazard_code",
+    "hazard_label",
+    "hazard_class",
+    "metric",
+    "value",
+    "unit",
+    "as_of_date",
+    "publication_date",
+    "publisher",
+    "source_type",
+    "source_url",
+    "doc_title",
+    "definition_text",
+    "method",
+    "confidence",
+    "revision",
+    "ingested_at",
+]
+
+NUM_RE = re.compile(
+    r"\b(?:about|approx\.?|around)?\s*([0-9][0-9., ]{0,15})(?:\s*(?:people|persons|individuals))?\b",
+    re.I,
+)
+
+
+def load_cfg() -> Dict[str, Any]:
+    with open(CONFIG, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def load_registries() -> Tuple[pd.DataFrame, pd.DataFrame]:
+    countries = pd.read_csv(COUNTRIES, dtype=str).fillna("")
+    shocks = pd.read_csv(SHOCKS, dtype=str).fillna("")
+    countries["country_norm"] = countries["country_name"].str.strip().str.lower()
+    return countries, shocks
+
+
+def norm(text: str) -> str:
+    return (text or "").strip().lower()
+
+
+def detect_hazard(text: str, cfg: Dict[str, Any]) -> Optional[str]:
+    sample = norm(text)
+    for code, keywords in cfg["hazard_keywords"].items():
+        for keyword in keywords:
+            if keyword in sample:
+                return code
+    return None
+
+
+def extract_metric_value(text: str, cfg: Dict[str, Any]) -> Optional[Tuple[str, int, str, str]]:
+    """Return (metric, value, unit, matched_phrase)."""
+
+    combined = text or ""
+    lowered = combined.lower()
+
+    for pattern_cfg in cfg["metric_patterns"]:
+        metric = pattern_cfg["metric"]
+        unit = pattern_cfg["unit"]
+        for phrase in pattern_cfg["patterns"]:
+            idx = lowered.find(phrase)
+            if idx == -1:
+                continue
+            window_start = max(0, idx - 80)
+            window_end = min(len(combined), idx + len(phrase) + 80)
+            window = combined[window_start:window_end]
+            match = NUM_RE.search(window)
+            if not match:
+                continue
+            raw_value = match.group(1)
+            cleaned = raw_value.replace(",", "").replace(" ", "")
+            cleaned = re.sub(r"[^0-9]", "", cleaned)
+            try:
+                value = int(cleaned)
+            except ValueError:
+                continue
+            if value < 0:
+                continue
+            return metric, value, unit, phrase
+    return None
+
+
+def iso3_from_reliefweb_countries(
+    countries_df: pd.DataFrame, rw_countries: List[Dict[str, Any]]
+) -> List[Tuple[str, str]]:
+    rows: List[Tuple[str, str]] = []
+    for country in rw_countries or []:
+        name = country.get("name") or country.get("shortname") or ""
+        if not name:
+            continue
+        match = countries_df[countries_df["country_name"].str.lower() == name.lower()]
+        if match.empty:
+            continue
+        rows.append((match.iloc[0]["country_name"], match.iloc[0]["iso3"]))
+    return rows
+
+
+def rw_request(
+    url: str,
+    payload: Dict[str, Any],
+    headers: Dict[str, str],
+    tries: int = 4,
+    backoff: float = 1.2,
+) -> Dict[str, Any]:
+    for attempt in range(1, tries + 1):
+        response = requests.post(url, json=payload, headers=headers, timeout=30)
+        if response.status_code == 200:
+            return response.json()
+        if response.status_code in (429, 502, 503):
+            time.sleep((backoff ** attempt) + 0.3 * attempt)
+            continue
+        response.raise_for_status()
+    raise RuntimeError("ReliefWeb API failed after retries")
+
+
+def build_payload(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    since = (
+        dt.datetime.utcnow() - dt.timedelta(days=int(cfg["window_days"]))
+    ).strftime("%Y-%m-%dT00:00:00Z")
+    fields = [
+        "id",
+        "title",
+        "body",
+        "date.created",
+        "date.original",
+        "date.changed",
+        "url",
+        "source",
+        "format",
+        "type",
+        "disaster_type",
+        "country",
+    ]
+    return {
+        "appname": cfg["appname"],
+        "filter": {
+            "operator": "AND",
+            "conditions": [
+                {"field": "date.created", "value": {"from": since}},
+                {"field": "language", "value": "en"},
+                {"field": "format", "value": ["Report", "Appeal", "Update"]},
+            ],
+        },
+        "fields": {"include": fields},
+        "sort": ["date.created:desc"],
+        "limit": int(cfg["page_size"]),
+    }
+
+
+def map_source_type(rw_type: str, cfg: Dict[str, Any]) -> str:
+    return cfg["source_type_map"].get(str(rw_type).lower(), "sitrep")
+
+
+def pick_dates(rec: Dict[str, Any]) -> Tuple[str, str]:
+    dates = rec.get("date", {}) or {}
+    created = (dates.get("created") or "").split("T")[0]
+    original = (dates.get("original") or "").split("T")[0]
+    as_of = original or created or ""
+    publication = created or as_of
+    return as_of, publication
+
+
+def make_rows() -> List[List[str]]:
+    cfg = load_cfg()
+    countries, shocks = load_registries()
+    iso_exclude = {code.upper() for code in cfg.get("iso3_exclude", [])}
+
+    headers = {
+        "User-Agent": cfg.get("user_agent", "spagbot-resolver"),
+        "Content-Type": "application/json",
+    }
+    url = cfg["base_url"]
+    payload = build_payload(cfg)
+
+    rows: List[List[str]] = []
+    offset = 0
+    total = None
+
+    while True:
+        payload["offset"] = offset
+        data = rw_request(url, payload, headers)
+        total = total or data.get("totalCount", 0)
+        items = data.get("data", [])
+        if not items:
+            break
+
+        for item in items:
+            report_id = str(item.get("id"))
+            fields = item.get("fields", {}) or {}
+            title = fields.get("title", "")
+            body = fields.get("body", "")
+            report_type_entries = fields.get("type") or [{}]
+            report_type = report_type_entries[0].get("name", "report")
+            sources = fields.get("source") or []
+            source_name = sources[0].get("shortname") if sources else "OCHA"
+
+            iso_pairs = iso3_from_reliefweb_countries(
+                countries, fields.get("country") or []
+            )
+            if not iso_pairs:
+                continue
+
+            hazard_code = detect_hazard(f"{title} {body}", cfg)
+            if not hazard_code:
+                continue
+
+            shock_row = shocks[shocks["hazard_code"] == hazard_code]
+            if shock_row.empty:
+                continue
+            hazard_label = shock_row.iloc[0]["hazard_label"]
+            hazard_class = shock_row.iloc[0]["hazard_class"]
+
+            text_for_metrics = " ".join([title or "", body or ""])
+            metric_info = extract_metric_value(text_for_metrics, cfg)
+            if not metric_info:
+                continue
+            metric, value, unit, phrase = metric_info
+
+            as_of, publication = pick_dates(fields)
+            source_url = fields.get("url", "")
+            doc_title = title
+
+            ingested_at = dt.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+            for country_name, iso3 in iso_pairs:
+                if iso3 in iso_exclude:
+                    continue
+                event_id = f"{iso3}-{hazard_code}-rw-{report_id}"
+                rows.append(
+                    [
+                        event_id,
+                        country_name,
+                        iso3,
+                        hazard_code,
+                        hazard_label,
+                        hazard_class,
+                        metric,
+                        str(value),
+                        unit,
+                        as_of,
+                        publication,
+                        source_name or "OCHA",
+                        map_source_type(report_type, cfg),
+                        source_url,
+                        doc_title,
+                        f"Extracted {metric} via phrase '{phrase}' in ReliefWeb report.",
+                        "api",
+                        "med",
+                        1,
+                        ingested_at,
+                    ]
+                )
+
+        offset += len(items)
+        if offset >= total:
+            break
+        time.sleep(0.25)
+
+    return rows
+
+
+def main() -> None:
+    STAGING.mkdir(parents=True, exist_ok=True)
+    output = STAGING / "reliefweb.csv"
+    rows = make_rows()
+
+    if not rows:
+        pd.DataFrame(columns=COLUMNS).to_csv(output, index=False)
+        print(f"wrote empty {output}")
+        return
+
+    df = pd.DataFrame(rows, columns=COLUMNS)
+    df.to_csv(output, index=False)
+    print(f"wrote {output} rows={len(df)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/resolver/ingestion/run_all_stubs.py
+++ b/resolver/ingestion/run_all_stubs.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent
 STUBS = [
-    "reliefweb_stub.py",
     "ifrc_go_stub.py",
     "unhcr_stub.py",
     "dtm_stub.py",
@@ -29,6 +28,16 @@ STUBS = [
 
 def main():
     failed = 0
+    reliefweb_client = ROOT / "reliefweb_client.py"
+    if reliefweb_client.exists():
+        print("==> running reliefweb_client.py")
+        res = subprocess.run([sys.executable, str(reliefweb_client)])
+        if res.returncode != 0:
+            print("reliefweb_client.py failed; continuing with stubs", file=sys.stderr)
+            failed += 1
+    else:
+        print("reliefweb_client.py missing; skipping real connector", file=sys.stderr)
+
     for stub in STUBS:
         path = ROOT / stub
         print(f"==> running {stub}")


### PR DESCRIPTION
## Summary
- add a ReliefWeb ingestion client that paginates the API, classifies hazards, and extracts PIN/PA metrics into staging CSV output
- capture connector configuration and update run_all_stubs to execute the real client before stubs
- document the new connector and mark ReliefWeb as an API source in the ingestion checklist

## Testing
- python resolver/ingestion/reliefweb_client.py *(fails: HTTPS proxy in CI blocks access to api.reliefweb.int)*

------
https://chatgpt.com/codex/tasks/task_e_68dd05b57bd8832cb11edb330d9dcb92