### PR TITLE
Handle ReliefWeb API v2 requirements and soften ingestion failure

### DIFF
--- a/resolver/ingestion/config/reliefweb.yml
+++ b/resolver/ingestion/config/reliefweb.yml
@@ -1,6 +1,7 @@
 appname: "spagbot-resolver"
 user_agent: "spagbot-resolver/1.0 (github.com/kwyjad/Spagbot_metac-bot)"
-base_url: "https://api.reliefweb.int/v1/reports"
+base_url: "https://api.reliefweb.int/v2/reports"
+accept_header: "application/json"
 window_days: 45
 page_size: 100
 

--- a/resolver/ingestion/run_all_stubs.py
+++ b/resolver/ingestion/run_all_stubs.py
@@ -30,11 +30,13 @@ def main():
     failed = 0
     reliefweb_client = ROOT / "reliefweb_client.py"
     if reliefweb_client.exists():
-        print("==> running reliefweb_client.py")
+        print("==> running reliefweb_client.py (real API)")
         res = subprocess.run([sys.executable, str(reliefweb_client)])
         if res.returncode != 0:
-            print("reliefweb_client.py failed; continuing with stubs", file=sys.stderr)
-            failed += 1
+            print(
+                "ReliefWeb client failed; continuing with other sources…",
+                file=sys.stderr,
+            )
     else:
         print("reliefweb_client.py missing; skipping real connector", file=sys.stderr)
 


### PR DESCRIPTION
## Summary
- update the ReliefWeb configuration and client to target the v2 endpoint with the required headers and query appname
- surface HTTP error details, adopt timezone-aware timestamps, and keep appname filtering aligned with the API expectations
- let the ingestion runner continue executing other stubs if the ReliefWeb client exits non-zero

## Testing
- python -m compileall resolver/ingestion/reliefweb_client.py resolver/ingestion/run_all_stubs.py

------
https://chatgpt.com/codex/tasks/task_e_68dd09abd27c832c884721cc7bd84f3d