### PR TITLE
[resolver] H1.1 — ReliefWeb connector: DEBUG logs, GET/POST fallback, and skip switch

### DIFF
--- a/resolver/ingestion/README.md
+++ b/resolver/ingestion/README.md
@@ -61,6 +61,18 @@ Hazards must match resolver/data/shocks.csv (e.g., FL, DR, TC, HW, ACO, ACE, ACC
 
 Earthquakes are out of scope by policy and are not included in stubs.
 
+### ReliefWeb troubleshooting
+
+- Set `RESOLVER_DEBUG=1` to log HTTP status, headers, and first 500 chars of any non-200 response.
+- Set `RESOLVER_SKIP_RELIEFWEB=1` to bypass the connector (writes an empty header-only CSV), useful if a proxy/WAF blocks the API.
+
+Example:
+
+```bash
+$env:RESOLVER_DEBUG="1"
+python resolver/ingestion/reliefweb_client.py
+```
+
 ## Source notes (what each adds)
 
 - **EM-DAT** — standardized disaster records and “people affected”; lagged but consistent.

--- a/resolver/ingestion/run_all_stubs.py
+++ b/resolver/ingestion/run_all_stubs.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
-"""
-Run all ingestion stubs to populate resolver/staging/*.csv
-"""
+"""Run all ingestion stubs to populate resolver/staging/*.csv."""
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -31,7 +30,10 @@ def main():
     reliefweb_client = ROOT / "reliefweb_client.py"
     if reliefweb_client.exists():
         print("==> running reliefweb_client.py (real API)")
-        res = subprocess.run([sys.executable, str(reliefweb_client)])
+        env = os.environ.copy()
+        if env.get("RESOLVER_SKIP_RELIEFWEB") == "1":
+            print("RESOLVER_SKIP_RELIEFWEB=1 — ReliefWeb connector will be skipped")
+        res = subprocess.run([sys.executable, str(reliefweb_client)], env=env)
         if res.returncode != 0:
             print(
                 "ReliefWeb client failed; continuing with other sources…",


### PR DESCRIPTION
## Summary
- add a DEBUG logging mode to the ReliefWeb client, including response dumps and retry diagnostics
- support an environment-driven skip path that writes an empty CSV to keep the pipeline running
- document the new environment flags and echo the skip status in the stub runner

## Testing
- RESOLVER_SKIP_RELIEFWEB=1 python resolver/ingestion/reliefweb_client.py

------
https://chatgpt.com/codex/tasks/task_e_68dd0e50f23c832c901dff1cf10478c4