### PR TITLE
[resolver] H1.3 — ReliefWeb appname = UNICEF-Resolver-P1L1T6 (+ env override)

### DIFF
--- a/resolver/ingestion/README.md
+++ b/resolver/ingestion/README.md
@@ -73,6 +73,17 @@ $env:RESOLVER_DEBUG="1"
 python resolver/ingestion/reliefweb_client.py
 ```
 
+### ReliefWeb appname
+
+- Default appname: `UNICEF-Resolver-P1L1T6` (set in `ingestion/config/reliefweb.yml`).
+- Override without code changes:
+  - Windows PowerShell: `$env:RELIEFWEB_APPNAME = "UNICEF-Resolver-P1L1T6"`
+  - Bash: `export RELIEFWEB_APPNAME="UNICEF-Resolver-P1L1T6"`
+
+After ReliefWeb approves your appname/IP:
+- Remove/avoid `RESOLVER_SKIP_RELIEFWEB=1` in CI/local.
+- (Optional) set `RESOLVER_DEBUG=1` once to verify 200/JSON, then turn it off.
+
 ## Source notes (what each adds)
 
 - **EM-DAT** — standardized disaster records and “people affected”; lagged but consistent.

--- a/resolver/ingestion/config/reliefweb.yml
+++ b/resolver/ingestion/config/reliefweb.yml
@@ -1,4 +1,4 @@
-appname: "spagbot-resolver"
+appname: "UNICEF-Resolver-P1L1T6"
 user_agent: "spagbot-resolver/1.0 (github.com/kwyjad/Spagbot_metac-bot)"
 base_url: "https://api.reliefweb.int/v2/reports"
 accept_header: "application/json"

--- a/resolver/ingestion/reliefweb_client.py
+++ b/resolver/ingestion/reliefweb_client.py
@@ -252,7 +252,8 @@ def make_rows() -> List[List[str]]:
         "Accept": cfg.get("accept_header", "application/json"),
     }
     base_url = cfg["base_url"]
-    appname = cfg.get("appname", "spagbot-resolver")
+    appname_cfg = cfg.get("appname", "spagbot-resolver")
+    appname = os.getenv("RELIEFWEB_APPNAME", appname_cfg)
     url = f"{base_url}?appname={appname}"
     payload = build_payload(cfg)
 


### PR DESCRIPTION
## Summary
- set the ReliefWeb connector default appname to UNICEF-Resolver-P1L1T6
- allow overriding the appname via the RELIEFWEB_APPNAME environment variable
- document the default, override instructions, and CI toggle guidance

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd12c56fa8832c80b9c0842c3b63c5