### PR TITLE
Add IFRC GO windowed pagination and update docs

### DIFF
--- a/resolver/ingestion/README.md
+++ b/resolver/ingestion/README.md
@@ -61,6 +61,13 @@ python resolver/tools/freeze_snapshot.py --facts resolver/exports/facts.csv --mo
   - `RESOLVER_SKIP_IFRCGO=1` — skip the connector (writes header-only CSV)
   - `RESOLVER_DEBUG=1` — verbose logging
 
+**Windowing & late edits**
+The connector now filters at the API with:
+- `created_at__gte=<YYYY-MM-DD>`
+- `updated_at__gte=<YYYY-MM-DD>`
+and early-exits paging when consecutive pages are fully older than the window. Hard caps guard against runaway pagination:
+`MAX_PAGES=50`, `MAX_RESULTS=5000`, and debug is throttled with `DEBUG_EVERY=10`.
+
 **Admin v2 details expansion**
 
 GO Admin v2 returns related fields as IDs unless you request `*_details`.

--- a/resolver/tests/README.md
+++ b/resolver/tests/README.md
@@ -8,12 +8,15 @@ These tests enforce basic contracts across:
 - Snapshots (`resolver/snapshots/YYYY-MM/facts.parquet`), if present
 - Remote-first state files under `resolver/state/**/exports/*.csv`
 
-## Run locally
+## Run locally (cross-platform)
 
 ```bash
-pip install pytest pandas pyarrow pyyaml python-dateutil
-pytest resolver/tests -q
+python -m pytest resolver/tests -q
 ```
+
+Use python -m pytest on Windows to avoid PATH issues (fixes “pytest is not recognized”).
+
+**CI already uses `pytest` in PATH** (via `pip install pytest`). That’s fine for Linux runners; no change needed there.
 
 Tests will skip gracefully if an expected file isn't present (e.g., snapshots),
 but will fail if a file exists and violates the contract.


### PR DESCRIPTION
## Summary
- add environment-configurable paging caps, early exit, and dual date filters to the IFRC GO collector
- document the windowing behavior and refresh the Windows-friendly pytest guidance

## Testing
- python -m pytest resolver/tests -q *(fails: ReliefWeb API blocked by proxy in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68dd20e30c04832cbb9e60117d1292c5