### PR TITLE
Make connector header tests hermetic

### DIFF
--- a/resolver/ingestion/reliefweb_client.py
+++ b/resolver/ingestion/reliefweb_client.py
@@ -261,6 +261,9 @@ def pick_dates(rec: Dict[str, Any]) -> Tuple[str, str]:
 
 
 def make_rows() -> List[List[str]]:
+    if os.getenv("RESOLVER_SKIP_RELIEFWEB", "") == "1":
+        return []
+
     cfg = load_cfg()
     countries, shocks = load_registries()
     iso_exclude = {code.upper() for code in cfg.get("iso3_exclude", [])}

--- a/resolver/tests/README.md
+++ b/resolver/tests/README.md
@@ -20,3 +20,7 @@ Use python -m pytest on Windows to avoid PATH issues (fixes “pytest is not rec
 
 Tests will skip gracefully if an expected file isn't present (e.g., snapshots),
 but will fail if a file exists and violates the contract.
+
+### Hermetic connector tests
+Header tests set `RESOLVER_SKIP_IFRCGO=1` and `RESOLVER_SKIP_RELIEFWEB=1` so no network is required.
+Each connector must still produce a CSV with the canonical header (even if empty).


### PR DESCRIPTION
## Summary
- ensure ReliefWeb connector short-circuits when RESOLVER_SKIP_RELIEFWEB=1
- make header tests hermetic by setting skip env vars before running connectors
- document the hermetic behavior in the tests README

## Testing
- python -m pytest resolver/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68dd2344c4f0832cac2a56eb5b69e8c3