### PR TITLE
chore: address resolver review items

### DIFF
--- a/.github/workflows/resolver-ci.yml
+++ b/.github/workflows/resolver-ci.yml
@@ -82,7 +82,7 @@ jobs:
           if ! git diff --cached --quiet; then
             git commit -m "chore(resolver): PR state for #$PR_NUMBER [skip ci]"
             # push back to the PR branch
-            git push
+            git push origin HEAD:${{ github.event.pull_request.head.ref }}
           else
             echo "No changes to commit."
           fi

--- a/resolver/cli/resolver_cli.py
+++ b/resolver/cli/resolver_cli.py
@@ -26,6 +26,7 @@ import json
 import sys
 from pathlib import Path
 from typing import Optional, Tuple
+from zoneinfo import ZoneInfo
 
 try:
     import pandas as pd
@@ -98,9 +99,17 @@ def resolve_hazard(
     )
 
 
-def current_ym_utc() -> str:
-    now = dt.datetime.utcnow()
+IST = ZoneInfo("Europe/Istanbul")
+
+
+def current_ym_istanbul() -> str:
+    now = dt.datetime.now(IST)
     return f"{now.year:04d}-{now.month:02d}"
+
+
+def current_ym_utc() -> str:
+    """Backwards-compatible alias; resolver now tracks Istanbul month boundary."""
+    return current_ym_istanbul()
 
 
 def ym_from_cutoff(cutoff: str) -> str:
@@ -191,7 +200,7 @@ def main() -> None:
     hazard_label, hazard_code, hazard_class = resolve_hazard(shocks, args.hazard, args.hazard_code)
 
     ym = ym_from_cutoff(args.cutoff)
-    current_month = ym == current_ym_utc()
+    current_month = ym == current_ym_istanbul()
     df, source_dataset = load_resolved_for_month(ym, current_month)
 
     if df is None:

--- a/resolver/ingestion/run_all_stubs.py
+++ b/resolver/ingestion/run_all_stubs.py
@@ -61,6 +61,7 @@ def main():
             res = subprocess.run([sys.executable, str(path)], env=env)
             if res.returncode != 0:
                 print("ReliefWeb client failed; continuing with other sources…", file=sys.stderr)
+                failed += 1
             continue
 
         print(f"==> running {script}")

--- a/resolver/review/apply_review_overrides.py
+++ b/resolver/review/apply_review_overrides.py
@@ -35,14 +35,14 @@ def main():
     merged = resolved.merge(dec, on="key", how="left", suffixes=("", "_dec"))
 
     out_rows = []
-    status = []
+    out_status = []
 
     for _, r in merged.iterrows():
         action = (r.get("analyst_decision", "") or "").strip().lower()
         row = r.copy()
+        status_label = "no_decision"
 
         if action == "drop":
-            status.append("dropped")
             continue
 
         elif action == "override":
@@ -58,20 +58,21 @@ def main():
                     row["definition_text"] = (
                         row.get("definition_text", "") + f" [OVERRIDE NOTE: {notes}]"
                     ).strip()
-                status.append("overridden")
+                status_label = "overridden"
             except Exception:
-                status.append("no_decision")
+                status_label = "no_decision"
 
         elif action == "keep":
-            status.append("kept")
+            status_label = "kept"
 
         else:
-            status.append("no_decision")
+            status_label = "no_decision"
 
         out_rows.append(row)
+        out_status.append(status_label)
 
     out = pd.DataFrame(out_rows).drop(columns=["key"], errors="ignore")
-    out["review_status"] = status[: len(out)]
+    out["review_status"] = out_status
 
     Path(args.out).parent.mkdir(parents=True, exist_ok=True)
     out.to_csv(args.out, index=False)

--- a/resolver/tools/export_facts.py
+++ b/resolver/tools/export_facts.py
@@ -115,7 +115,7 @@ def _apply_mapping(df: pd.DataFrame, cfg: Dict[str, Any]) -> pd.DataFrame:
         if val is None:
             out[target] = ""  # will fill from constants/defaults later
         else:
-            out[target] = val.astype(str).fillna("")
+            out[target] = val.fillna("").astype(str)
 
     # Date mapping (same approach)
     for target, sources in dates.items():

--- a/spagbot/io_logs.py
+++ b/spagbot/io_logs.py
@@ -370,8 +370,12 @@ def commit_and_push_logs(changed_paths: Iterable[Path], commit_message: Optional
                 check=True,
             )
         except subprocess.CalledProcessError as pull_err:
+            try:
+                subprocess.run(["git", "rebase", "--abort"], cwd=repo, check=False)
+            except Exception:
+                pass
             print(
-                f"[git] pull --rebase failed ({pull_err.returncode}); leaving commit local",
+                f"[git] pull --rebase failed ({pull_err.returncode}); aborted rebase; leaving commit local",
                 file=sys.stderr,
             )
             return True


### PR DESCRIPTION
## Summary
- union the IFRC GO created/updated query windows, request the affected field, and deduplicate records per endpoint before emitting rows
- use the ReliefWeb GET call as a connectivity probe only, count runner failures, and push CI commits to the pull request head ref
- align the CLI month boundary with Europe/Istanbul, harden precedence/export/review helpers, and abort failed git rebases so automation can continue cleanly

## Testing
- pytest resolver/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68dd26d16588832c83f4163b01daec90