### PR TITLE
[resolver] R2 — Dev bootstrap for tests (requirements-dev + docs + ignores)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,8 @@ gtmc_logs/
 # Optional OS files
 .DS_Store
 Thumbs.db
+
+# Python build/test artifacts
+__pycache__/
+.pytest_cache/
+*.pyc

--- a/resolver/README.md
+++ b/resolver/README.md
@@ -159,4 +159,18 @@ Query it:
 curl "http://127.0.0.1:8000/resolve?iso3=PHL&hazard_code=TC&cutoff=2025-09-30"
 ```
 
+### Developer setup (tests)
+
+For local tests, install dev deps once:
+
+```
+python -m pip install -r resolver/requirements-dev.txt
+```
+
+Then run:
+
+```
+python -m pytest resolver/tests -q
+```
+
 OpenAPI docs at /docs.

--- a/resolver/requirements-dev.txt
+++ b/resolver/requirements-dev.txt
@@ -1,0 +1,9 @@
+# Dev/test-only deps; keep aligned with CI
+pytest>=8.3
+pytest-cov>=5.0
+# runtime deps used by tests and tools
+pandas>=2.3
+pyarrow>=15.0
+pyyaml>=6.0
+requests>=2.31
+python-dateutil>=2.9

--- a/resolver/tests/README.md
+++ b/resolver/tests/README.md
@@ -10,13 +10,23 @@ These tests enforce basic contracts across:
 
 ## Run locally (cross-platform)
 
+First install dev requirements:
+
+```powershell
+# Windows PowerShell
+python -m pip install -r resolver/requirements-dev.txt
+```
+
+```bash
+# macOS/Linux
+python3 -m pip install -r resolver/requirements-dev.txt
+```
+
+Then run tests:
+
 ```bash
 python -m pytest resolver/tests -q
 ```
-
-Use python -m pytest on Windows to avoid PATH issues (fixes “pytest is not recognized”).
-
-**CI already uses `pytest` in PATH** (via `pip install pytest`). That’s fine for Linux runners; no change needed there.
 
 Tests will skip gracefully if an expected file isn't present (e.g., snapshots),
 but will fail if a file exists and violates the contract.


### PR DESCRIPTION
## Summary
- add resolver/requirements-dev.txt capturing the dev/test dependency set used in CI
- update resolver README files with cross-platform instructions for installing dev deps and running pytest
- extend the repository .gitignore to keep Python cache artifacts out of version control

## Testing
- not run (docs and configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68dd2b70390c832ca9fbf51856f80608