### PR TITLE
Switch UNHCR connector to asylum applications endpoint

### DIFF
--- a/resolver/ingestion/README.md
+++ b/resolver/ingestion/README.md
@@ -136,10 +136,16 @@ Flip it to `"0"` once ReliefWeb confirms your appname/IP.
 ## UNHCR Population — real connector
 
 - **Endpoint (configurable):** `https://api.unhcr.org/population/v1/` (see `config/unhcr.yml`).
-- **What we extract:** recent **arrivals** per country of asylum → mapped to **Displacement Influx (DI)** with `metric=affected`, `unit=persons`.
+- **What we extract:** recent **asylum applications** per country of asylum → mapped to **Displacement Influx (DI)** with `metric=affected`, `unit=persons`.
 - **Dates:** Prefer year+month (mid-month as_of), else `updated_at`; publication_date mirrors as_of unless `record_date` present.
 - **Env:** `RESOLVER_SKIP_UNHCR=1`, `RESOLVER_DEBUG=1`, `RESOLVER_MAX_PAGES`, `RESOLVER_MAX_RESULTS`, `RESOLVER_DEBUG_EVERY`.
 - **Fail-soft:** Writes header-only CSV on errors so the pipeline keeps running.
+
+**Endpoint & mapping**
+
+UNHCR’s public API exposes `/asylum-applications/`, `/population/`, `/asylum-decisions/` (no `/arrivals/`). We query
+`/asylum-applications/` with `cf_type=ISO` and a **year window** (this year + previous if needed) and map the count to
+**DI (Displacement Influx)** with `metric=affected, unit=persons`. See the official API docs.  
 
 ## Source notes (what each adds)
 

--- a/resolver/ingestion/config/unhcr.yml
+++ b/resolver/ingestion/config/unhcr.yml
@@ -3,25 +3,18 @@ user_agent: "spagbot-resolver/1.0 (github.com/kwyjad/Spagbot_metac-bot)"
 window_days: 60
 page_size: 500
 
-# Endpoint for monthly arrivals by asylum country (configurable)
-# We keep this generic so you can swap paths without code changes if UNHCR adjusts names.
 endpoints:
-  arrivals: "arrivals/"
+  # Use official public endpoint (docs show these resources)
+  # https://api.unhcr.org/population/v1/asylum-applications/
+  asylum_applications: "asylum-applications/"
 
-# Columns in the response we prefer (connector will tolerate missing ones)
-# Common UNHCR fields include: year, month, origin_country_iso3, asylum_country_iso3, individuals, updated_at
-preferred_fields:
-  - "year"
-  - "month"
-  - "asylum_country_iso3"
-  - "country_of_asylum_iso3"
-  - "origin_country_iso3"
-  - "individuals"
-  - "updated_at"
-  - "date"
-  - "record_date"
+# Request parameters to keep results ISO3-coded and broad by default
+params:
+  cf_type: "ISO"
+  # coo_all/coa_all let the API expand dimensions instead of aggregating away
+  coo_all: "true"
+  coa_all: "true"
 
-# Caps and throttle (mirrors other connectors; can be overridden via env)
 defaults:
   max_pages: 40
   max_results: 20000

--- a/resolver/ingestion/unhcr_client.py
+++ b/resolver/ingestion/unhcr_client.py
@@ -2,7 +2,7 @@
 """
 UNHCR Population API → staging/unhcr.csv
 
-Pulls recent cross-border displacement arrivals and emits canonical rows for
+Pulls recent cross-border asylum application counts and emits canonical rows for
 DI (Displacement Influx) with metric=affected, unit=persons.
 
 ENV:
@@ -17,7 +17,8 @@ Registries: resolver/data/countries.csv, resolver/data/shocks.csv
 """
 
 from __future__ import annotations
-import os, time, datetime as dt
+import hashlib
+import os, datetime as dt
 from typing import Dict, Any, List, Optional
 from pathlib import Path
 
@@ -74,147 +75,142 @@ def iso3_to_name(df_c: pd.DataFrame, iso3: str) -> Optional[str]:
         return None
     return row.iloc[0]["country_name"]
 
+
+def _stable_digest(parts: list[str], length: int = 12) -> str:
+    """
+    Deterministic, short hex digest for IDs.
+    Join parts with a separator to avoid accidental collisions.
+    """
+    key = "|".join(parts).encode("utf-8")
+    return hashlib.sha256(key).hexdigest()[:length]
+
 def make_rows() -> List[List[str]]:
     if os.getenv("RESOLVER_SKIP_UNHCR","") == "1":
         return []
 
     cfg = load_cfg()
     base = cfg["base_url"]
-    arrivals_path = cfg["endpoints"]["arrivals"]
-    headers = {
-        "User-Agent": cfg["user_agent"],
-        "Accept": "application/json",
-    }
-    df_countries, df_shocks = load_registries()
+    path = cfg["endpoints"]["asylum_applications"]
+    headers = {"User-Agent": cfg["user_agent"], "Accept": "application/json"}
 
-    # DI hazard registry row
-    di = df_shocks[df_shocks["hazard_code"] == "DI"]
-    if di.empty:
-        return []
-    hz_code = "DI"
-    hz_label = di.iloc[0]["hazard_label"]
-    hz_class = di.iloc[0]["hazard_class"]
-
-    # window bounds
     since_dt = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=int(cfg["window_days"]))
-    since = since_dt.date().isoformat()
+    since = since_dt.date()
 
-    # caps
+    today = dt.date.today()
+    years = {today.year}
+    if since.year < today.year:
+        years.add(since.year)
+
+    params_cfg = cfg.get("params", {}) or {}
+    common_params = {
+        "cf_type": params_cfg.get("cf_type", "ISO"),
+        "coo_all": params_cfg.get("coo_all", "true"),
+        "coa_all": params_cfg.get("coa_all", "true"),
+    }
+
+    rows: List[List[str]] = []
     MAX_PAGES = _int_env("RESOLVER_MAX_PAGES", int(cfg["defaults"]["max_pages"]))
     MAX_RESULTS = _int_env("RESOLVER_MAX_RESULTS", int(cfg["defaults"]["max_results"]))
     DEBUG_EVERY = _int_env("RESOLVER_DEBUG_EVERY", int(cfg["defaults"]["debug_every"]))
-
-    rows: List[List[str]] = []
-    total_made = 0
-    page = 0
-    offset = 0
     page_size = int(cfg["page_size"])
 
-    # UNHCR population API typically supports limit/offset and filters by year/month or date.
-    # We request recent data; connector tolerates variants by filtering client-side as well.
-    while True:
-        params = {
-            "limit": page_size,
-            "offset": offset,
-            # Prefer updated records too; some deployments expose 'updated_at__gte'
-            # If unsupported, server ignores it; we still filter client-side below.
-            "updated_at__gte": since,
-        }
-        url = base.rstrip("/") + "/" + arrivals_path.lstrip("/")
-        r = requests.get(url, params=params, headers=headers, timeout=30)
-        page += 1
-        if _debug() and (page % DEBUG_EVERY == 1):
-            dbg(f"GET {r.url} -> {r.status_code}")
-        if r.status_code != 200:
-            # Fail-soft
-            break
+    df_countries, df_shocks = load_registries()
+    di = df_shocks[df_shocks["hazard_code"] == "DI"]
+    if di.empty:
+        return []
+    hz_code, hz_label, hz_class = "DI", di.iloc[0]["hazard_label"], di.iloc[0]["hazard_class"]
 
-        data = r.json()
-        # Shape can be {count, next, results} or plain list
-        results = data.get("results") if isinstance(data, dict) else (data if isinstance(data, list) else [])
-        if not results:
-            break
-
-        # Parse each item; tolerate schema variation via .get().
-        emitted_this_page = 0
-        for it in results:
-            # Pull iso3 for asylum country
-            asylum_iso = (it.get("asylum_country_iso3")
-                          or it.get("country_of_asylum_iso3")
-                          or "").strip().upper()
-            country_name = iso3_to_name(df_countries, asylum_iso)
-            if not asylum_iso or not country_name:
-                continue
-
-            # Individuals / arrivals count
-            val = it.get("individuals")
-            try:
-                value = int(val) if val is not None else None
-            except Exception:
-                value = None
-            if value is None or value < 0:
-                continue
-
-            # Dates: prefer record-level updated_at or explicit year/month
-            updated = str(it.get("updated_at") or "")[:10]
-            year = str(it.get("year") or "")
-            month = str(it.get("month") or "")
-            # Build a YYYY-MM-15 "as_of" if year+month present; else fallback to updated or today
-            as_of = ""
-            if year and month and month.isdigit():
-                y = year
-                m = f"{int(month):02d}"
-                as_of = f"{y}-{m}-15"
-            elif updated:
-                as_of = updated
-            else:
-                as_of = dt.date.today().isoformat()
-
-            # Publication date = same as_of by default; if explicit record_date provided, use it
-            pub = str(it.get("record_date") or it.get("date") or as_of)[:10]
-
-            # Client-side window filter (union of created/updated logic):
-            if (as_of < since) and (pub < since) and (not updated or updated < since):
-                continue
-
-            src_url = url  # UNHCR API endpoint (could be enhanced with per-record link if available)
-            title = f"UNHCR arrivals — {country_name}"
-            definition = "Individuals newly arrived (cross-border) reported by UNHCR Population API; treated as Displacement Influx (DI)."
-
-            event_id = f"{asylum_iso}-DI-unhcr-{year or ''}{month or ''}-{abs(hash((asylum_iso, as_of, value)))%10_000_000}"
-
-            rows.append([
-                event_id, country_name, asylum_iso,
-                hz_code, hz_label, hz_class,
-                "affected", str(value), "persons",
-                as_of, pub,
-                "UNHCR", "stat", src_url, title,
-                definition,
-                "api", "med", 1, dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-            ])
-            total_made += 1
-            emitted_this_page += 1
-            if total_made >= MAX_RESULTS:
-                dbg(f"hit MAX_RESULTS={MAX_RESULTS}, stopping")
+    total = 0
+    for yr in sorted(years, reverse=True):
+        page = 0
+        offset = 0
+        while True:
+            params = {
+                "limit": page_size,
+                "page": (offset // page_size) + 1,
+                "yearFrom": yr,
+                "yearTo": yr,
+                **common_params,
+            }
+            url = base.rstrip("/") + "/" + path.lstrip("/")
+            r = requests.get(url, params=params, headers=headers, timeout=30)
+            page += 1
+            if _debug() and (page % DEBUG_EVERY == 1):
+                dbg(f"GET {r.url} -> {r.status_code}")
+            if r.status_code != 200:
                 break
 
-        if total_made >= MAX_RESULTS:
-            break
+            data = r.json()
+            results = data.get("results") if isinstance(data, dict) else (data if isinstance(data, list) else [])
+            if not results:
+                break
 
-        # Early exit if page produced nothing and appears stale
-        if emitted_this_page == 0:
-            # crude: if first item has a date and it's older than window, count older-only page
-            pass  # we rely on MAX_PAGES + natural empty/next logic
+            for it in results:
+                asylum_iso = (it.get("coa") or it.get("country_of_asylum") or "").strip().upper()
+                country_name = iso3_to_name(df_countries, asylum_iso)
+                if not asylum_iso or not country_name:
+                    continue
 
-        # Pagination
-        if isinstance(data, dict) and data.get("next"):
+                val = it.get("value") or it.get("applications") or it.get("individuals")
+                try:
+                    value = int(val) if val is not None else None
+                except Exception:
+                    value = None
+                if value is None or value < 0:
+                    continue
+
+                as_of = f"{yr}-12-31"
+                pub = dt.date.today().isoformat()
+
+                if dt.date.fromisoformat(as_of) < since and dt.date.fromisoformat(pub) < since:
+                    continue
+
+                title = f"UNHCR asylum applications — {country_name} ({yr})"
+                definition = (
+                    "Applications for international protection filed in the year; used here as a proxy for cross-border "
+                    "Displacement Influx (DI)."
+                )
+                src_url = url
+
+                origin_iso = (it.get("coo") or it.get("country_of_origin") or "").strip().upper() or "-"
+                rid = _stable_digest([asylum_iso, origin_iso, str(yr), "apps", as_of, str(value)], length=12)
+                event_id = f"{asylum_iso}-DI-unhcr-apps-{yr}-{rid}"
+
+                rows.append([
+                    event_id,
+                    country_name,
+                    asylum_iso,
+                    hz_code,
+                    hz_label,
+                    hz_class,
+                    "affected",
+                    str(value),
+                    "persons",
+                    as_of,
+                    pub,
+                    "UNHCR",
+                    "stat",
+                    src_url,
+                    title,
+                    definition,
+                    "api",
+                    "med",
+                    1,
+                    dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                ])
+                total += 1
+                if total >= MAX_RESULTS:
+                    dbg(f"hit MAX_RESULTS={MAX_RESULTS}, stopping")
+                    break
+
+            if total >= MAX_RESULTS:
+                break
+
+            if len(results) < page_size or page >= MAX_PAGES:
+                break
             offset += page_size
-            time.sleep(0.15)
-            if page >= MAX_PAGES:
-                dbg(f"hit MAX_PAGES={MAX_PAGES}, stopping")
-                break
-            continue
-        else:
+
+        if total >= MAX_RESULTS:
             break
 
     return rows


### PR DESCRIPTION
## Summary
- point the UNHCR config at the public asylum-applications endpoint with ISO3 defaults and paging caps
- rewrite the UNHCR client to query asylum-applications using the configured window, generate stable event IDs, and map counts to DI
- document the endpoint choice and DI proxy mapping in the ingestion README

## Testing
- not run (network calls mocked/disabled in CI)


------
https://chatgpt.com/codex/tasks/task_e_68dd333f7be4832c96b9a2d4448d6f29