### PR TITLE
Extend validator for series semantics metadata

### DIFF
--- a/resolver/tools/schema.yml
+++ b/resolver/tools/schema.yml
@@ -23,3 +23,24 @@ required:
 enums:
   metric: [in_need, affected, displaced, cases]
   unit: [persons, persons_cases]
+
+optional:
+  series_semantics:
+    type: string
+    enum: [stock, new]
+    required: false
+  value_new:
+    type: number
+    required: false
+  value_stock:
+    type: number
+    required: false
+  rebase_flag:
+    type: integer
+    required: false
+  first_observation:
+    type: integer
+    required: false
+  delta_negative_clamped:
+    type: integer
+    required: false


### PR DESCRIPTION
## Summary
- add optional schema fields describing series semantics and delta metadata
- extend validate_facts.py to warn about contradictory "new" definitions and simultaneous value_new/value_stock entries
- require ym fields to match a YYYY-MM pattern during validation

## Testing
- python -m compileall resolver/tools/validate_facts.py

------
https://chatgpt.com/codex/tasks/task_e_68de62ba5b8c832c84e147d1eb916e1b