### PR TITLE
Add WHO PHE connector for monthly incident ingestion

### DIFF
--- a/resolver/ingestion/README.md
+++ b/resolver/ingestion/README.md
@@ -14,6 +14,7 @@ Later (Epic C) we will replace stubs with real API/scraper clients.
 - IFRC GO — **API connector** (`ifrc_go_client.py`) → `staging/ifrc_go.csv`
 - UNHCR ODP — **API connector** (`unhcr_odp_client.py`) → `staging/unhcr_odp.csv`
 - IOM DTM — **API connector** (`dtm_client.py`) → `staging/dtm.csv`
+- WHO Public Health Emergencies — **API connector** (`who_phe_client.py`) → `staging/who_phe.csv`
 - WHO Emergencies — stub (`who_stub.py`)
 - IPC — stub (`ipc_stub.py`)
 - EM-DAT — stub (`emdat_stub.py`)
@@ -172,6 +173,19 @@ UNHCR’s public API exposes `/asylum-applications/`, `/population/`, `/asylum-d
 - `DTM_DEFAULT_HAZARD=<key>` — override the fallback hazard keyword (default `displacement_influx`).
 - `DTM_BASE=<url>` — override the base discovery endpoint (defaults to `https://data.humdata.org`).
 - `RELIEFWEB_APPNAME` — reused for User-Agent hints when hitting HDX mirrors.
+
+## WHO Public Health Emergencies — real connector
+
+- **Phase 1 sources:** Config-driven CSV/XLSX feeds listed in `ingestion/config/who_phe.yml` (WHO direct or HDX mirrors).
+- **Metric:** Monthly-first **new cases** per ISO3 mapped to `hazard_code=PHE`, `metric=affected`, `unit=persons`.
+- **Series semantics:** Daily/weekly incident series are summed to month start; cumulative series are converted to month-over-month deltas (first month dropped unless `WHO_PHE_ALLOW_FIRST_MONTH=1`).
+- **PIN expansion:** Optional `WHO_PHE_PIN_RATIO=<float>` emits parallel `metric=in_need` rows using an integer-rounded ratio of cases.
+- **Output:** Deterministic `event_id` (`<iso3>-WHO-phe-<metric>-YYYY-MM-<digest>`), `publisher="WHO"`, `source_type="official"`, `method="WHO PHE; monthly-first; …"` with frequency/delta hints.
+- **Env toggles:**
+  - `RESOLVER_SKIP_WHO=1` — skip connector (writes header-only CSV).
+  - `WHO_PHE_ALLOW_FIRST_MONTH=1` — retain the first month from cumulative series instead of dropping it.
+  - `WHO_PHE_PIN_RATIO=0.2` (example) — emit `in_need` rows alongside `affected`.
+  - `RESOLVER_MAX_RESULTS=<int>` / `RESOLVER_DEBUG=1` follow the shared ingestion conventions.
 
 ## HDX (CKAN) — real connector
 

--- a/resolver/ingestion/config/who_phe.yml
+++ b/resolver/ingestion/config/who_phe.yml
@@ -1,0 +1,23 @@
+# Phase-1 WHO Public Health Emergency sources
+sources:
+  - name: cholera_global
+    kind: csv
+    url: https://example.org/cholera_cases_by_week.csv
+    time_keys: ["week", "year"]
+    country_keys: ["iso3", "country", "country_code", "#country+code"]
+    case_keys: ["cases", "new_cases", "#affected+cases"]
+    disease: cholera
+    series_hint: incident
+
+  - name: measles_global
+    kind: csv
+    url: https://example.org/measles_cases_by_week.csv
+    time_keys: ["week", "year"]
+    country_keys: ["iso3", "country", "country_code", "#country+code"]
+    case_keys: ["cases", "new_cases", "#affected+cases"]
+    disease: measles
+    series_hint: incident
+
+prefer_hxl: true
+monthly_first: true
+allow_first_month_delta: false

--- a/resolver/ingestion/run_all_stubs.py
+++ b/resolver/ingestion/run_all_stubs.py
@@ -13,6 +13,7 @@ STUBS = [
     "unhcr_client.py",        # real connector (fail-soft/skip-capable)
     "unhcr_odp_client.py",    # real connector (fail-soft/skip-capable)
     "dtm_client.py",          # real connector (fail-soft/skip-capable)
+    "who_phe_client.py",      # real connector (fail-soft/skip-capable)
     "reliefweb_client.py",    # real connector (may be skipped via env)
     "hdx_client.py",          # real connector (fail-soft/skip-capable)
     "dtm_stub.py",
@@ -119,6 +120,25 @@ def main():
                 continue
             if not ok:
                 print("DTM client produced no rows", file=sys.stderr)
+            continue
+
+        if script == "who_phe_client.py":
+            if env.get("RESOLVER_SKIP_WHO") == "1":
+                print("RESOLVER_SKIP_WHO=1 — WHO PHE connector will be skipped")
+                continue
+            if not path.exists():
+                print("who_phe_client.py missing; skipping WHO connector", file=sys.stderr)
+                continue
+            print("==> running who_phe_client.py")
+            try:
+                mod = importlib.import_module("resolver.ingestion.who_phe_client")
+                ok = mod.main()
+            except Exception as exc:
+                print(f"WHO PHE client raised {exc}; continuing with other sources…", file=sys.stderr)
+                failed += 1
+                continue
+            if not ok:
+                print("WHO PHE connector produced no rows", file=sys.stderr)
             continue
 
         if script == "hdx_client.py":

--- a/resolver/ingestion/who_phe_client.py
+++ b/resolver/ingestion/who_phe_client.py
@@ -1,0 +1,645 @@
+#!/usr/bin/env python3
+"""WHO Public Health Emergency (PHE) connector."""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import io
+import math
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, MutableMapping, Optional, Sequence, Tuple
+
+import pandas as pd
+import requests
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA = ROOT / "data"
+STAGING = ROOT / "staging"
+CONFIG = ROOT / "ingestion" / "config" / "who_phe.yml"
+COUNTRIES = DATA / "countries.csv"
+
+OUT_PATH = STAGING / "who_phe.csv"
+
+CANONICAL_HEADERS = [
+    "event_id",
+    "country_name",
+    "iso3",
+    "hazard_code",
+    "hazard_label",
+    "hazard_class",
+    "metric",
+    "series_semantics",
+    "value",
+    "unit",
+    "as_of_date",
+    "publication_date",
+    "publisher",
+    "source_type",
+    "source_url",
+    "doc_title",
+    "definition_text",
+    "method",
+    "confidence",
+    "revision",
+    "ingested_at",
+]
+
+SERIES_INCIDENT = "incident"
+SERIES_CUMULATIVE = "cumulative"
+
+HAZARD_CODE = "PHE"
+HAZARD_LABEL = "Public Health Emergency"
+HAZARD_CLASS = "health"
+
+DEBUG = os.getenv("RESOLVER_DEBUG", "0") == "1"
+
+
+def dbg(message: str) -> None:
+    if DEBUG:
+        print(f"[who_phe] {message}")
+
+
+@dataclass
+class SourceFrame:
+    df: pd.DataFrame
+    column_map: Dict[str, str]
+    hxl_map: Dict[str, str]
+    hxl_present: bool
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    val = os.getenv(name)
+    if val is None:
+        return default
+    return str(val).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def load_config() -> Dict[str, Any]:
+    if not CONFIG.exists():
+        return {"sources": []}
+    with open(CONFIG, "r", encoding="utf-8") as fp:
+        return yaml.safe_load(fp) or {"sources": []}
+
+
+def load_countries() -> Tuple[pd.DataFrame, Dict[str, str], Dict[str, str]]:
+    countries = pd.read_csv(COUNTRIES, dtype=str).fillna("")
+    iso3_to_name = {row.iso3: row.country_name for row in countries.itertuples(index=False)}
+    name_to_iso3: Dict[str, str] = {}
+    for row in countries.itertuples(index=False):
+        key = _normalise_country(row.country_name)
+        if key and key not in name_to_iso3:
+            name_to_iso3[key] = row.iso3
+    return countries, iso3_to_name, name_to_iso3
+
+
+def _normalise_country(name: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", str(name or "").strip().lower())
+
+
+def _normalise_key(text: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", str(text or "").strip().lower())
+
+
+def _is_hxl_row(values: Iterable[Any]) -> bool:
+    seen = False
+    for value in values:
+        if value is None or (isinstance(value, float) and math.isnan(value)):
+            return False
+        text = str(value).strip()
+        if not text:
+            return False
+        if not text.startswith("#"):
+            return False
+        seen = True
+    return seen
+
+
+def _prepare_frame(df: pd.DataFrame) -> SourceFrame:
+    hxl_map: Dict[str, str] = {}
+    hxl_present = False
+    if not df.empty:
+        for idx in list(df.index[:2]):
+            row = df.loc[idx]
+            if _is_hxl_row(row.values):
+                hxl_present = True
+                tags = [str(v).strip() for v in row.values]
+                for col, tag in zip(df.columns, tags):
+                    if tag:
+                        hxl_map[col] = tag
+                df = df.drop(index=idx)
+    df = df.reset_index(drop=True)
+    column_map: Dict[str, str] = {}
+    for col in df.columns:
+        norm = _normalise_key(col)
+        if norm and norm not in column_map:
+            column_map[norm] = col
+        tag = hxl_map.get(col)
+        if tag:
+            norm_tag = _normalise_key(tag)
+            if norm_tag and norm_tag not in column_map:
+                column_map[norm_tag] = col
+    return SourceFrame(df=df, column_map=column_map, hxl_map=hxl_map, hxl_present=hxl_present)
+
+
+def _find_column(frame: SourceFrame, candidates: Sequence[str]) -> Optional[str]:
+    for cand in candidates:
+        norm = _normalise_key(cand)
+        if not norm:
+            continue
+        if norm in frame.column_map:
+            return frame.column_map[norm]
+    return None
+
+
+def _parse_value(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        value = value.strip()
+        if not value:
+            return None
+    try:
+        return float(value)
+    except Exception:
+        return None
+
+
+def _parse_date(value: Any) -> Optional[pd.Timestamp]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    parsed = pd.to_datetime(text, errors="coerce")
+    if pd.isna(parsed):
+        return None
+    if isinstance(parsed, pd.Timestamp):
+        return parsed
+    try:
+        return pd.Timestamp(parsed)
+    except Exception:
+        return None
+
+
+def _parse_week(year_val: Any, week_val: Any) -> Optional[pd.Timestamp]:
+    try:
+        year = int(float(year_val))
+        week = int(float(week_val))
+    except Exception:
+        return None
+    if year <= 0 or week <= 0:
+        return None
+    try:
+        return pd.to_datetime(f"{year}-W{week:02d}-1", format="%G-W%V-%u")
+    except Exception:
+        return None
+
+
+def _parse_month_value(value: Any, year_val: Any = None) -> Optional[pd.Timestamp]:
+    text = str(value or "").strip()
+    if not text and year_val is None:
+        return None
+    if year_val is not None and text:
+        try:
+            year = int(float(year_val))
+        except Exception:
+            year = None
+        try:
+            month = int(float(text))
+        except Exception:
+            month = None
+        if year and month and 1 <= month <= 12:
+            return pd.Timestamp(dt.date(year, month, 1))
+    parsed = pd.to_datetime(text, errors="coerce")
+    if pd.isna(parsed):
+        return None
+    return pd.Timestamp(parsed)
+
+
+def _month_key(ts: pd.Timestamp) -> str:
+    return f"{ts.year:04d}-{ts.month:02d}"
+
+
+def _detect_series_type(source: Dict[str, Any], case_col: Optional[str], frame: SourceFrame) -> str:
+    hint = str(source.get("series_hint", "infer") or "").strip().lower()
+    if hint in {SERIES_INCIDENT, SERIES_CUMULATIVE}:
+        return hint
+    texts: List[str] = []
+    if case_col:
+        texts.append(case_col)
+        tag = frame.hxl_map.get(case_col)
+        if tag:
+            texts.append(tag)
+    for key in (source.get("case_keys") or []):
+        texts.append(str(key))
+    blob = " ".join(t.lower() for t in texts if t)
+    if any(token in blob for token in ["new", "incident", "weekly", "wk"]):
+        return SERIES_INCIDENT
+    if any(token in blob for token in ["cumulative", "total", "overall", "cum"]):
+        return SERIES_CUMULATIVE
+    return SERIES_INCIDENT
+
+
+def _detect_time_shape(time_keys: Sequence[str]) -> str:
+    keys = " ".join(str(k).lower() for k in time_keys)
+    if "week" in keys:
+        return "weekly"
+    if "date" in keys or "day" in keys:
+        return "daily"
+    if "month" in keys:
+        return "monthly"
+    return "unknown"
+
+
+def _load_remote(url: str) -> io.BytesIO:
+    headers: Dict[str, str] = {}
+    ua = os.getenv("RELIEFWEB_APPNAME")
+    if ua:
+        headers["User-Agent"] = ua
+    resp = requests.get(url, headers=headers, timeout=60)
+    resp.raise_for_status()
+    return io.BytesIO(resp.content)
+
+
+def _load_frame(source: Dict[str, Any]) -> SourceFrame:
+    url = str(source.get("url", "")).strip()
+    kind = str(source.get("kind", "csv") or "csv").lower()
+    if not url:
+        raise ValueError("source missing url")
+    buf: io.BytesIO | Path
+    if url.startswith("http://") or url.startswith("https://"):
+        dbg(f"fetching {url}")
+        buf = _load_remote(url)
+    else:
+        path = Path(url)
+        if not path.is_absolute():
+            path = ROOT / url
+        if not path.exists():
+            raise FileNotFoundError(f"source path not found: {path}")
+        buf = path
+    if kind == "xlsx" or kind == "xls":
+        df = pd.read_excel(buf, dtype=str)
+    else:
+        df = pd.read_csv(buf, dtype=str)
+    return _prepare_frame(df)
+
+
+@dataclass
+class ParsedRow:
+    iso3: str
+    timestamp: pd.Timestamp
+    month: str
+    value: float
+
+
+def _standardise_iso3(
+    row: MutableMapping[str, Any],
+    *,
+    iso_col: Optional[str],
+    country_col: Optional[str],
+    name_to_iso3: Dict[str, str],
+) -> Optional[str]:
+    if iso_col:
+        raw = row.get(iso_col)
+        text = str(raw or "").strip()
+        if text:
+            iso = text.upper()
+            if len(iso) == 3:
+                return iso
+            key = _normalise_country(text)
+            if key and key in name_to_iso3:
+                return name_to_iso3[key]
+    if country_col:
+        raw = row.get(country_col)
+        key = _normalise_country(raw)
+        if key and key in name_to_iso3:
+            return name_to_iso3[key]
+    return None
+
+
+def _parse_rows_for_source(
+    source: Dict[str, Any],
+    frame: SourceFrame,
+    name_to_iso3: Dict[str, str],
+) -> Tuple[List[ParsedRow], str]:
+    time_keys: Sequence[str] = source.get("time_keys", []) or []
+    country_keys: Sequence[str] = source.get("country_keys", []) or []
+    case_keys: Sequence[str] = source.get("case_keys", []) or []
+
+    iso_candidates = [k for k in country_keys if any(token in str(k).lower() for token in ("iso", "code"))]
+    name_candidates = [k for k in country_keys if k not in iso_candidates]
+
+    iso_col = _find_column(frame, iso_candidates or country_keys)
+    country_col = _find_column(frame, name_candidates)
+    if country_col is None and iso_col is not None:
+        country_col = iso_col
+    month_col = _find_column(frame, [k for k in time_keys if "month" in str(k).lower()])
+    date_col = _find_column(frame, [k for k in time_keys if "date" in str(k).lower() or "day" in str(k).lower()])
+    week_col = _find_column(frame, [k for k in time_keys if "week" in str(k).lower()])
+    year_col = _find_column(frame, [k for k in time_keys if "year" in str(k).lower()])
+
+    case_col = _find_column(frame, case_keys)
+    if case_col is None:
+        raise ValueError("no case column found")
+
+    series_type = _detect_series_type(source, case_col, frame)
+    time_shape = _detect_time_shape(time_keys)
+
+    parsed_rows: List[ParsedRow] = []
+
+    for record in frame.df.to_dict(orient="records"):
+        iso3 = _standardise_iso3(record, iso_col=iso_col, country_col=country_col, name_to_iso3=name_to_iso3)
+        if not iso3:
+            continue
+        if iso3 == "" or iso3.upper() == "UNK":
+            continue
+
+        timestamp: Optional[pd.Timestamp] = None
+        if date_col:
+            timestamp = _parse_date(record.get(date_col))
+        if timestamp is None and month_col:
+            timestamp = _parse_month_value(record.get(month_col), record.get(year_col))
+        if timestamp is None and week_col and year_col:
+            timestamp = _parse_week(record.get(year_col), record.get(week_col))
+        if timestamp is None and date_col is None and week_col and "week" not in str(time_keys).lower():
+            timestamp = _parse_week(record.get(year_col), record.get(week_col))
+        if timestamp is None:
+            continue
+
+        month = _month_key(timestamp)
+        value = _parse_value(record.get(case_col))
+        if value is None:
+            continue
+
+        parsed_rows.append(ParsedRow(iso3=iso3, timestamp=timestamp, month=month, value=value))
+
+    return parsed_rows, series_type
+
+
+def _aggregate_monthly(
+    rows: Sequence[ParsedRow],
+    *,
+    series_type: str,
+    allow_first_month: bool,
+) -> Dict[str, float]:
+    if not rows:
+        return {}
+    df = pd.DataFrame([{"iso3": r.iso3, "timestamp": r.timestamp, "month": r.month, "value": r.value} for r in rows])
+    df = df.sort_values("timestamp")
+    totals: Dict[str, float] = {}
+    if series_type == SERIES_CUMULATIVE:
+        monthly_last = df.groupby("month")[["timestamp", "value"]].last()
+        months_sorted = sorted(monthly_last.index, key=lambda m: pd.Period(m, freq="M"))
+        prev: Optional[float] = None
+        for month in months_sorted:
+            value = float(monthly_last.loc[month, "value"])
+            if prev is None:
+                if allow_first_month:
+                    totals[month] = max(value, 0.0)
+                prev = value
+                continue
+            delta = value - prev
+            if delta < 0:
+                delta = 0.0
+            totals[month] = delta
+            prev = value
+    else:
+        monthly_sum = df.groupby("month")["value"].sum()
+        for month, value in monthly_sum.items():
+            totals[month] = max(float(value), 0.0)
+    return totals
+
+
+def _round_persons(value: float) -> int:
+    if value is None:
+        return 0
+    return int(round(float(value)))
+
+
+def build_event_id(
+    iso3: str,
+    metric: str,
+    as_of_date: str,
+    value: Any,
+    source_url: str,
+    phe_type: str,
+) -> str:
+    try:
+        year, month = as_of_date.split("-")[:2]
+    except ValueError:
+        year, month = "0000", "00"
+    digest = hashlib.sha1(
+        "|".join([
+            str(iso3 or "UNK"),
+            str(metric or ""),
+            str(as_of_date or ""),
+            str(value or 0),
+            str(source_url or ""),
+            str(phe_type or ""),
+        ]).encode("utf-8")
+    ).hexdigest()[:12]
+    return f"{iso3}-WHO-phe-{metric}-{year}-{month}-{digest}"
+
+
+def _write_header_only(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(columns=CANONICAL_HEADERS).to_csv(path, index=False)
+
+
+def _write_rows(rows: Sequence[Dict[str, Any]], *, path: Path) -> None:
+    if not rows:
+        _write_header_only(path)
+        return
+    df = pd.DataFrame(rows)
+    for col in CANONICAL_HEADERS:
+        if col not in df.columns:
+            df[col] = ""
+    df = df[CANONICAL_HEADERS]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(path, index=False)
+
+
+def collect_rows() -> List[Dict[str, Any]]:
+    cfg = load_config()
+    sources = cfg.get("sources", []) or []
+    if not sources:
+        return []
+
+    _, iso3_to_name, name_to_iso3 = load_countries()
+
+    allow_first_month = _env_bool(
+        "WHO_PHE_ALLOW_FIRST_MONTH",
+        bool(cfg.get("allow_first_month_delta", False)),
+    )
+
+    pin_ratio_env = os.getenv("WHO_PHE_PIN_RATIO")
+    pin_ratio: Optional[float] = None
+    if pin_ratio_env:
+        try:
+            pin_ratio = float(pin_ratio_env)
+        except Exception:
+            pin_ratio = None
+        if pin_ratio is not None and pin_ratio <= 0:
+            pin_ratio = None
+
+    ingested_at = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    rows_out: List[Dict[str, Any]] = []
+
+    max_results: Optional[int] = None
+    max_env = os.getenv("RESOLVER_MAX_RESULTS")
+    if max_env:
+        try:
+            max_results = max(0, int(max_env))
+        except Exception:
+            max_results = None
+
+    for source in sources:
+        name = str(source.get("name") or "who_phe").strip()
+        disease = str(source.get("disease") or "PHE").strip()
+        source_url = str(source.get("url", ""))
+        publication_date = str(source.get("publication_date", ""))
+        doc_title = source.get("doc_title") or f"WHO PHE {disease} surveillance"
+
+        try:
+            frame = _load_frame(source)
+        except Exception as exc:
+            dbg(f"source {name} failed to load: {exc}")
+            continue
+
+        try:
+            parsed_rows, series_type = _parse_rows_for_source(source, frame, name_to_iso3)
+        except Exception as exc:
+            dbg(f"source {name} parse error: {exc}")
+            continue
+
+        if not parsed_rows:
+            dbg(f"source {name} produced no usable rows")
+            continue
+
+        monthly_totals_by_iso: Dict[str, Dict[str, float]] = {}
+        for iso3, group in _group_rows_by_iso(parsed_rows).items():
+            totals = _aggregate_monthly(group, series_type=series_type, allow_first_month=allow_first_month)
+            if not totals:
+                continue
+            monthly_totals_by_iso[iso3] = totals
+
+        if not monthly_totals_by_iso:
+            continue
+
+        time_shape = _detect_time_shape(source.get("time_keys", []) or [])
+        method_parts = ["WHO PHE", "monthly-first"]
+        if time_shape == "weekly":
+            method_parts.append("weekly→monthly sum")
+        elif time_shape == "daily":
+            method_parts.append("daily→monthly sum")
+        elif time_shape == "monthly":
+            method_parts.append("monthly direct")
+        if series_type == SERIES_CUMULATIVE:
+            method_parts.append("delta-on-cumulative")
+        else:
+            method_parts.append("incident")
+        method = "; ".join(method_parts)
+
+        definition_bits = [f"{disease} cases"]
+        if series_type == SERIES_CUMULATIVE:
+            definition_bits.append("cumulative series converted to incident deltas")
+        else:
+            definition_bits.append("incident series")
+        if frame.hxl_present:
+            definition_bits.append("HXL tags detected")
+        definition_text = "; ".join(definition_bits)
+
+        for iso3, totals in monthly_totals_by_iso.items():
+            country_name = iso3_to_name.get(iso3, "")
+            if not country_name:
+                continue
+            for month, value in sorted(totals.items()):
+                persons = _round_persons(value)
+                if persons < 0:
+                    persons = 0
+                row_base = {
+                    "event_id": build_event_id(iso3, "affected", month, persons, source_url, disease),
+                    "country_name": country_name,
+                    "iso3": iso3,
+                    "hazard_code": HAZARD_CODE,
+                    "hazard_label": HAZARD_LABEL,
+                    "hazard_class": HAZARD_CLASS,
+                    "metric": "affected",
+                    "series_semantics": SERIES_INCIDENT,
+                    "value": persons,
+                    "unit": "persons",
+                    "as_of_date": month,
+                    "publication_date": publication_date,
+                    "publisher": "WHO",
+                    "source_type": "official",
+                    "source_url": source_url,
+                    "doc_title": doc_title,
+                    "definition_text": definition_text,
+                    "method": method,
+                    "confidence": "",
+                    "revision": 0,
+                    "ingested_at": ingested_at,
+                }
+                rows_out.append(row_base)
+
+                if pin_ratio is not None and pin_ratio > 0:
+                    pin_value = _round_persons(persons * pin_ratio)
+                    pin_row = dict(row_base)
+                    pin_row["metric"] = "in_need"
+                    pin_row["value"] = pin_value
+                    pin_row["event_id"] = build_event_id(
+                        iso3,
+                        "in_need",
+                        month,
+                        pin_value,
+                        source_url,
+                        disease,
+                    )
+                    rows_out.append(pin_row)
+
+        if max_results is not None and len(rows_out) >= max_results:
+            rows_out = rows_out[:max_results]
+            break
+
+    rows_out.sort(key=lambda r: (r.get("iso3", ""), r.get("as_of_date", ""), r.get("metric", "")))
+    return rows_out
+
+
+def _group_rows_by_iso(rows: Sequence[ParsedRow]) -> Dict[str, List[ParsedRow]]:
+    grouped: Dict[str, List[ParsedRow]] = {}
+    for row in rows:
+        grouped.setdefault(row.iso3, []).append(row)
+    return grouped
+
+
+def main() -> bool:
+    if os.getenv("RESOLVER_SKIP_WHO") == "1":
+        dbg("RESOLVER_SKIP_WHO=1 — skipping WHO connector")
+        _write_header_only(OUT_PATH)
+        return False
+
+    try:
+        rows = collect_rows()
+    except Exception as exc:
+        dbg(f"collect_rows failed: {exc}")
+        _write_header_only(OUT_PATH)
+        return False
+
+    if not rows:
+        dbg("no WHO PHE rows collected; writing header only")
+        _write_header_only(OUT_PATH)
+        return False
+
+    _write_rows(rows, path=OUT_PATH)
+    print(f"wrote {OUT_PATH}")
+    return True
+
+
+if __name__ == "__main__":
+    main()

--- a/resolver/tests/test_connectors_headers.py
+++ b/resolver/tests/test_connectors_headers.py
@@ -50,6 +50,15 @@ def test_hdx_header(tmp_path, monkeypatch):
     _assert_header(STAGING / "hdx.csv")
 
 
+def test_who_phe_header(tmp_path, monkeypatch):
+    monkeypatch.setenv("RESOLVER_SKIP_WHO", "1")
+    mod = importlib.import_module("resolver.ingestion.who_phe_client")
+    tmp_out = Path(tmp_path) / "who_phe.csv"
+    mod.OUT_PATH = tmp_out
+    mod.main()
+    _assert_header(tmp_out)
+
+
 def test_dtm_header_written(tmp_path, monkeypatch):
     monkeypatch.setenv("RESOLVER_SKIP_DTM", "1")
     from resolver.ingestion import dtm_client

--- a/resolver/tests/test_who_phe_monthly_resample.py
+++ b/resolver/tests/test_who_phe_monthly_resample.py
@@ -1,0 +1,131 @@
+import importlib
+from pathlib import Path
+
+import pandas as pd
+
+
+def _write_csv(path: Path, rows):
+    df = pd.DataFrame(rows)
+    df.to_csv(path, index=False)
+
+
+def test_who_phe_monthly_resample(tmp_path, monkeypatch):
+    monkeypatch.delenv("RESOLVER_SKIP_WHO", raising=False)
+    monkeypatch.delenv("WHO_PHE_PIN_RATIO", raising=False)
+    monkeypatch.delenv("WHO_PHE_ALLOW_FIRST_MONTH", raising=False)
+
+    weekly_path = tmp_path / "weekly_incident.csv"
+    _write_csv(
+        weekly_path,
+        [
+            {"iso3": "KEN", "year": 2024, "week": 1, "cases": 5},
+            {"iso3": "KEN", "year": 2024, "week": 2, "cases": 4},
+            {"iso3": "KEN", "year": 2024, "week": 6, "cases": 10},
+        ],
+    )
+
+    daily_path = tmp_path / "daily_incident.csv"
+    _write_csv(
+        daily_path,
+        [
+            {"iso3": "UGA", "date": "2024-01-01", "cases": 3},
+            {"iso3": "UGA", "date": "2024-01-12", "cases": 2},
+            {"iso3": "UGA", "date": "2024-02-15", "cases": 7},
+        ],
+    )
+
+    cumulative_path = tmp_path / "cumulative_weekly.csv"
+    _write_csv(
+        cumulative_path,
+        [
+            {"iso3": "ETH", "year": 2024, "week": 1, "cases": 10},
+            {"iso3": "ETH", "year": 2024, "week": 4, "cases": 25},
+            {"iso3": "ETH", "year": 2024, "week": 6, "cases": 40},
+            {"iso3": "ETH", "year": 2024, "week": 8, "cases": 45},
+            {"iso3": "ETH", "year": 2024, "week": 10, "cases": 30},
+        ],
+    )
+
+    subnational_path = tmp_path / "subnational.csv"
+    _write_csv(
+        subnational_path,
+        [
+            {"iso3": "TCD", "admin1": "Region A", "date": "2024-01-02", "cases": 2},
+            {"iso3": "TCD", "admin1": "Region B", "date": "2024-01-05", "cases": 3},
+            {"iso3": "TCD", "admin1": "Region A", "date": "2024-02-10", "cases": 4},
+            {"iso3": "TCD", "admin1": "Region B", "date": "2024-02-12", "cases": 6},
+        ],
+    )
+
+    config = tmp_path / "who_phe.yml"
+    config.write_text(
+        "\n".join(
+            [
+                "sources:",
+                f"  - name: weekly_incident",
+                f"    kind: csv",
+                f"    url: {weekly_path}",
+                f"    time_keys: ['week', 'year']",
+                f"    country_keys: ['iso3']",
+                f"    case_keys: ['cases']",
+                f"    disease: cholera",
+                f"    series_hint: incident",
+                f"  - name: daily_incident",
+                f"    kind: csv",
+                f"    url: {daily_path}",
+                f"    time_keys: ['date']",
+                f"    country_keys: ['iso3']",
+                f"    case_keys: ['cases']",
+                f"    disease: measles",
+                f"    series_hint: incident",
+                f"  - name: cumulative_weekly",
+                f"    kind: csv",
+                f"    url: {cumulative_path}",
+                f"    time_keys: ['week', 'year']",
+                f"    country_keys: ['iso3']",
+                f"    case_keys: ['cases']",
+                f"    disease: cholera",
+                f"    series_hint: cumulative",
+                f"  - name: subnational_daily",
+                f"    kind: csv",
+                f"    url: {subnational_path}",
+                f"    time_keys: ['date']",
+                f"    country_keys: ['iso3']",
+                f"    case_keys: ['cases']",
+                f"    disease: cholera",
+                f"    series_hint: incident",
+                "prefer_hxl: false",
+                "allow_first_month_delta: false",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    mod = importlib.import_module("resolver.ingestion.who_phe_client")
+    monkeypatch.setattr(mod, "CONFIG", config)
+    output = tmp_path / "who_phe.csv"
+    monkeypatch.setattr(mod, "OUT_PATH", output)
+
+    mod.main()
+
+    df = pd.read_csv(output)
+
+    ken = df[df["iso3"] == "KEN"].set_index("as_of_date")
+    assert int(ken.loc["2024-01", "value"]) == 9
+    assert int(ken.loc["2024-02", "value"]) == 10
+
+    uga = df[df["iso3"] == "UGA"].set_index("as_of_date")
+    assert int(uga.loc["2024-01", "value"]) == 5
+    assert int(uga.loc["2024-02", "value"]) == 7
+
+    eth = df[df["iso3"] == "ETH"].set_index("as_of_date")
+    assert "2024-01" not in eth.index
+    assert int(eth.loc["2024-02", "value"]) == 20
+    assert int(eth.loc["2024-03", "value"]) == 0
+
+    tcd = df[df["iso3"] == "TCD"].set_index("as_of_date")
+    assert int(tcd.loc["2024-01", "value"]) == 5
+    assert int(tcd.loc["2024-02", "value"]) == 10
+
+    assert set(df["hazard_code"]) == {"PHE"}
+    assert set(df["series_semantics"]) == {"incident"}

--- a/resolver/tests/test_who_phe_pin_mapping.py
+++ b/resolver/tests/test_who_phe_pin_mapping.py
@@ -1,0 +1,66 @@
+import importlib
+from pathlib import Path
+
+import pandas as pd
+
+
+def test_who_phe_pin_ratio(tmp_path, monkeypatch):
+    monkeypatch.setenv("WHO_PHE_PIN_RATIO", "0.2")
+    monkeypatch.delenv("RESOLVER_SKIP_WHO", raising=False)
+    monkeypatch.delenv("WHO_PHE_ALLOW_FIRST_MONTH", raising=False)
+
+    data_path = tmp_path / "cases.csv"
+    pd.DataFrame(
+        [
+            {"iso3": "MLI", "date": "2024-01-10", "cases": 50},
+            {"iso3": "MLI", "date": "2024-01-20", "cases": 30},
+            {"iso3": "MLI", "date": "2024-02-12", "cases": 20},
+        ]
+    ).to_csv(data_path, index=False)
+
+    config = tmp_path / "who_phe.yml"
+    config.write_text(
+        "\n".join(
+            [
+                "sources:",
+                f"  - name: malaria_daily",
+                f"    kind: csv",
+                f"    url: {data_path}",
+                f"    time_keys: ['date']",
+                f"    country_keys: ['iso3']",
+                f"    case_keys: ['cases']",
+                f"    disease: malaria",
+                f"    series_hint: incident",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    mod = importlib.import_module("resolver.ingestion.who_phe_client")
+    monkeypatch.setattr(mod, "CONFIG", config)
+    output = tmp_path / "who_phe.csv"
+    monkeypatch.setattr(mod, "OUT_PATH", output)
+
+    mod.main()
+
+    df = pd.read_csv(output)
+    assert set(df["metric"]) == {"affected", "in_need"}
+    grouped = df.groupby("metric").get_group
+
+    affected = grouped("affected").iloc[0]
+    pin = grouped("in_need").iloc[0]
+
+    assert affected["iso3"] == "MLI"
+    assert affected["as_of_date"] == "2024-01"
+    assert int(affected["value"]) == 80
+    assert int(pin["value"]) == 16
+
+    aff_parts = affected["event_id"].split("-")
+    pin_parts = pin["event_id"].split("-")
+    assert aff_parts[:3] == ["MLI", "WHO", "phe"]
+    assert pin_parts[:3] == ["MLI", "WHO", "phe"]
+    assert aff_parts[4:6] == pin_parts[4:6]
+    assert aff_parts[3] == "affected"
+    assert pin_parts[3] == "in_need"
+
+    assert pin["doc_title"] == affected["doc_title"]

--- a/resolver/tools/precedence_config.yml
+++ b/resolver/tools/precedence_config.yml
@@ -4,6 +4,7 @@ source_precedence:                       # highest → lowest
   - inter_agency_plan
   - ifrc_or_gov_sitrep
   - un_cluster_snapshot
+  - who
   - reputable_ingo_un
   - dtm                                   # DTM alongside HDX for movement PIN
   - hdx                                   # HDX connector (between direct agency and media)
@@ -21,6 +22,9 @@ source_mapping:
   un_cluster_snapshot:
     source_type: ["cluster"]
     publisher: ["UNHCR", "IOM-DTM", "WHO", "IPC"]
+  who:
+    source_type: ["official"]
+    publisher: ["WHO"]
   reputable_ingo_un:
     source_type: ["agency"]
     publisher: ["EM-DAT", "GDACS", "Copernicus EMS", "UNOSAT", "FEWS NET", "WFP mVAM"]
@@ -48,5 +52,6 @@ cutoff:
   lag_days_allowed: 7
 
 lags:
+  who: 2d
   dtm: 2d
   hdx: 3d


### PR DESCRIPTION
## Summary
- implement a WHO Public Health Emergency connector with monthly-first aggregation, optional PIN conversion, and deterministic event IDs
- register the connector in the stub runner, precedence policy, and ingestion docs with a configuration stub
- add connector header, resampling, and PIN ratio tests

## Testing
- pytest resolver/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68de72f2ee64832cbdf25ac462bee432