### PR TITLE
Add IPC ingestion connector with monthly expansion and tests

### DIFF
--- a/resolver/ingestion/config/ipc.yml
+++ b/resolver/ingestion/config/ipc.yml
@@ -1,0 +1,28 @@
+sources:
+  - name: ipc_global_rounds
+    kind: csv
+    url: https://example.com/ipc.csv
+    country_keys: ["iso3", "country", "adm0_name", "#country+code"]
+    period_start_keys: ["period_start", "start", "start_month", "#date+start", "#date"]
+    period_end_keys: ["period_end", "end", "end_month", "#date+end"]
+    phase3p_keys: ["phase3plus", "p3plus", "ipc3plus", "#population+phase+3plus", "#inneed"]
+    phase4p_keys: ["phase4plus", "ipc4plus", "#population+phase+4plus"]
+    phase5_keys: ["phase5", "#population+phase+5"]
+    drivers_keys: ["drivers", "driver", "hazard", "cause", "tags", "notes"]
+    title_keys: ["doc_title", "title"]
+    publication_keys: ["publication_date", "pub_date", "date"]
+    source_url_keys: ["source_url", "source", "url"]
+    publisher: "IPC"
+    source_type: "official"
+prefer_hxl: true
+monthly_first: true
+shock_keywords:
+  drought: ["drought", "dry spell", "rainfall deficit"]
+  flood: ["flood", "heavy rain", "inundation"]
+  armed_conflict_escalation: ["conflict", "insecurity", "violence", "hostilities", "armed"]
+  economic_crisis: ["economic", "inflation", "market", "prices", "currency", "livelihoods"]
+  phe: ["cholera", "measles", "outbreak", "epidemic", "pandemic"]
+emit_stock: true
+emit_incident: true
+include_first_month_delta: false
+default_hazard: multi

--- a/resolver/ingestion/ipc_client.py
+++ b/resolver/ingestion/ipc_client.py
@@ -1,0 +1,630 @@
+#!/usr/bin/env python3
+"""IPC (Integrated Food Security Classification) connector."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, MutableMapping, Optional, Sequence, Tuple
+
+import pandas as pd
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA = ROOT / "data"
+STAGING = ROOT / "staging"
+CONFIG = ROOT / "ingestion" / "config" / "ipc.yml"
+
+COUNTRIES = DATA / "countries.csv"
+SHOCKS = DATA / "shocks.csv"
+
+OUT_PATH = STAGING / "ipc.csv"
+
+CANONICAL_HEADERS = [
+    "event_id",
+    "country_name",
+    "iso3",
+    "hazard_code",
+    "hazard_label",
+    "hazard_class",
+    "metric",
+    "series_semantics",
+    "value",
+    "unit",
+    "as_of_date",
+    "publication_date",
+    "publisher",
+    "source_type",
+    "source_url",
+    "doc_title",
+    "definition_text",
+    "method",
+    "confidence",
+    "revision",
+    "ingested_at",
+]
+
+SERIES_STOCK = "stock"
+SERIES_INCIDENT = "incident"
+
+HAZARD_KEY_TO_CODE = {
+    "drought": "DR",
+    "flood": "FL",
+    "armed_conflict_escalation": "ACE",
+    "economic_crisis": "EC",
+    "phe": "PHE",
+}
+
+MULTI_HAZARD = ("multi", "Multi-driver Food Insecurity", "complex")
+
+DEBUG = os.getenv("RESOLVER_DEBUG", "0") == "1"
+
+
+def dbg(message: str) -> None:
+    if DEBUG:
+        print(f"[ipc] {message}")
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    val = os.getenv(name)
+    if val is None:
+        return default
+    return str(val).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _env_int(name: str) -> Optional[int]:
+    val = os.getenv(name)
+    if val is None:
+        return None
+    try:
+        return int(str(val).strip())
+    except ValueError:
+        return None
+
+
+def load_config() -> Dict[str, Any]:
+    if not CONFIG.exists():
+        return {"sources": []}
+    with open(CONFIG, "r", encoding="utf-8") as fp:
+        cfg = yaml.safe_load(fp) or {}
+    cfg.setdefault("sources", [])
+    return cfg
+
+
+def load_registries() -> Tuple[pd.DataFrame, Dict[str, str], Dict[str, Tuple[str, str]]]:
+    countries = pd.read_csv(COUNTRIES, dtype=str).fillna("")
+    shocks = pd.read_csv(SHOCKS, dtype=str).fillna("")
+    iso3_to_name = {row.iso3: row.country_name for row in countries.itertuples(index=False)}
+    hazard_lookup: Dict[str, Tuple[str, str]] = {}
+    for row in shocks.itertuples(index=False):
+        hazard_lookup[row.hazard_code] = (row.hazard_label, row.hazard_class)
+    return countries, iso3_to_name, hazard_lookup
+
+
+def _normalise_key(text: Any) -> str:
+    return re.sub(r"[^a-z0-9]", "", str(text or "").strip().lower())
+
+
+def _is_hxl_row(values: Iterable[Any]) -> bool:
+    seen = False
+    for value in values:
+        if value is None:
+            return False
+        if isinstance(value, float) and math.isnan(value):
+            return False
+        text = str(value).strip()
+        if not text or not text.startswith("#"):
+            return False
+        seen = True
+    return seen
+
+
+@dataclass
+class SourceFrame:
+    df: pd.DataFrame
+    column_map: Dict[str, str]
+    hxl_map: Dict[str, str] = field(default_factory=dict)
+
+
+def _prepare_frame(df: pd.DataFrame) -> SourceFrame:
+    df = df.copy()
+    hxl_map: Dict[str, str] = {}
+    # Drop leading HXL rows and register their tags
+    for idx in list(df.index[:2]):
+        row = df.loc[idx]
+        if _is_hxl_row(row.values):
+            tags = [str(v).strip() for v in row.values]
+            for col, tag in zip(df.columns, tags):
+                if tag:
+                    hxl_map[col] = tag
+            df = df.drop(index=idx)
+    df = df.reset_index(drop=True)
+    column_map: Dict[str, str] = {}
+    for col in df.columns:
+        norm = _normalise_key(col)
+        if norm and norm not in column_map:
+            column_map[norm] = col
+        tag = hxl_map.get(col)
+        if tag:
+            norm_tag = _normalise_key(tag)
+            if norm_tag and norm_tag not in column_map:
+                column_map[norm_tag] = col
+    return SourceFrame(df=df, column_map=column_map, hxl_map=hxl_map)
+
+
+def _find_column(frame: SourceFrame, candidates: Sequence[str]) -> Optional[str]:
+    for cand in candidates:
+        norm = _normalise_key(cand)
+        if not norm:
+            continue
+        if norm in frame.column_map:
+            return frame.column_map[norm]
+    return None
+
+
+def _normalise_month(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        parsed = pd.to_datetime(text, errors="coerce")
+    except Exception:
+        parsed = pd.NaT
+    if pd.isna(parsed):
+        return None
+    return f"{int(parsed.year):04d}-{int(parsed.month):02d}"
+
+
+def _normalise_date(value: Any) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if not text:
+        return ""
+    try:
+        parsed = pd.to_datetime(text, errors="coerce")
+    except Exception:
+        parsed = pd.NaT
+    if pd.isna(parsed):
+        return ""
+    return parsed.strftime("%Y-%m-%d")
+
+
+def _expand_period(start: Any, end: Any) -> List[str]:
+    start_month = _normalise_month(start)
+    end_month = _normalise_month(end)
+    if not start_month or not end_month:
+        return []
+    start_ts = pd.to_datetime(start_month)
+    end_ts = pd.to_datetime(end_month)
+    if pd.isna(start_ts) or pd.isna(end_ts):
+        return []
+    if end_ts < start_ts:
+        start_ts, end_ts = end_ts, start_ts
+    months = pd.period_range(start_ts, end_ts, freq="M")
+    return [f"{p.year:04d}-{p.month:02d}" for p in months]
+
+
+def _parse_people(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if "%" in text or "percent" in text.lower():
+        return None
+    cleaned = text.replace(",", "").replace(" ", "")
+    try:
+        number = float(cleaned)
+    except ValueError:
+        return None
+    if math.isnan(number) or number < 0:
+        return None
+    return float(number)
+
+
+def _digest(parts: Sequence[Any]) -> str:
+    joined = "|".join(str(p) for p in parts)
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()[:12]
+
+
+def _ingested_timestamp() -> str:
+    return pd.Timestamp.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@dataclass
+class MonthlyRecord:
+    iso3: str
+    country_name: str
+    hazard_code: str
+    hazard_label: str
+    hazard_class: str
+    month: str
+    value: float
+    source_key: str
+    source_url: str
+    doc_title: str
+    publication_date: str
+    definition_parts: List[str]
+    drivers_text: str
+    method_notes: str
+    publisher: str
+    source_type: str
+
+
+def _resolve_hazard(
+    drivers: str,
+    *,
+    cfg: Dict[str, Any],
+    hazard_lookup: Dict[str, Tuple[str, str]],
+    default_key: str,
+) -> Tuple[str, str, str]:
+    default_key = default_key or "multi"
+    text = str(drivers or "").lower()
+    if text:
+        for hazard_key, keywords in cfg.get("shock_keywords", {}).items():
+            if hazard_key not in HAZARD_KEY_TO_CODE:
+                continue
+            for keyword in keywords or []:
+                if keyword and keyword.lower() in text:
+                    code = HAZARD_KEY_TO_CODE[hazard_key]
+                    label, hclass = hazard_lookup.get(code, (hazard_key.title(), ""))
+                    return code, label, hclass
+    # Fallback to configured default
+    if default_key in HAZARD_KEY_TO_CODE:
+        code = HAZARD_KEY_TO_CODE[default_key]
+        label, hclass = hazard_lookup.get(code, (default_key.title(), ""))
+        return code, label, hclass
+    return MULTI_HAZARD
+
+
+def _merge_definition(existing: List[str], addition: str) -> List[str]:
+    if not addition:
+        return existing
+    if addition not in existing:
+        existing.append(addition)
+    return existing
+
+
+def _load_source_frame(source: Dict[str, Any]) -> SourceFrame:
+    if "data" in source:
+        df = pd.DataFrame(source.get("data", []))
+    else:
+        kind = (source.get("kind") or "csv").lower()
+        url = source.get("url")
+        if not url:
+            return SourceFrame(df=pd.DataFrame(), column_map={})
+        if kind == "xlsx":
+            df = pd.read_excel(url, dtype=str, engine="openpyxl" if os.getenv("IPC_FORCE_OPENPYXL") else None)
+        else:
+            df = pd.read_csv(url, dtype=str)
+    df = df.fillna("")
+    return _prepare_frame(df)
+
+
+def _lookup_value(row: MutableMapping[str, Any], column: Optional[str]) -> Any:
+    if column is None:
+        return None
+    return row.get(column)
+
+
+def _best_of(row: MutableMapping[str, Any], frame: SourceFrame, keys: Sequence[str]) -> Any:
+    column = _find_column(frame, keys)
+    if column:
+        return row.get(column)
+    return None
+
+
+def _series_source_key(source: Dict[str, Any]) -> str:
+    key = source.get("name") or source.get("url") or "ipc"
+    return _normalise_key(key) or "ipc"
+
+
+def _definition_from_row(
+    *,
+    period_start: str,
+    period_end: str,
+    phase4: Optional[float],
+    phase5: Optional[float],
+    drivers: str,
+) -> str:
+    parts = ["IPC Acute Food Insecurity Phase 3+ population estimate."]
+    if period_start and period_end:
+        parts.append(f"Period: {period_start} to {period_end} (inclusive of all months).")
+    elif period_start:
+        parts.append(f"Period starting {period_start}.")
+    if phase4 is not None:
+        parts.append(f"Phase 4+: {int(phase4):,} (if reported).")
+    if phase5 is not None:
+        parts.append(f"Phase 5: {int(phase5):,} (if reported).")
+    if drivers:
+        parts.append(f"Reported drivers: {drivers}.")
+    return " ".join(parts)
+
+
+def _collect_rows(
+    *,
+    cfg: Dict[str, Any],
+    emit_stock: bool,
+    emit_incident: bool,
+    include_first_delta: bool,
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    _, iso3_to_name, hazard_lookup = load_registries()
+    stock_rows: Dict[Tuple[str, str, str, str], MonthlyRecord] = {}
+
+    default_hazard_key = os.getenv("IPC_DEFAULT_HAZARD", cfg.get("default_hazard", "multi"))
+
+    for source in cfg.get("sources", []):
+        frame = _load_source_frame(source)
+        if frame.df.empty:
+            continue
+        dbg(f"processing source {source.get('name', 'ipc')} with {len(frame.df)} rows")
+
+        country_keys = source.get("country_keys") or []
+        period_start_keys = source.get("period_start_keys") or []
+        period_end_keys = source.get("period_end_keys") or []
+        phase3p_keys = source.get("phase3p_keys") or []
+        phase4p_keys = source.get("phase4p_keys") or []
+        phase5_keys = source.get("phase5_keys") or []
+        drivers_keys = source.get("drivers_keys") or []
+        title_keys = source.get("title_keys") or ["doc_title", "title", "dataset_title"]
+        publication_keys = source.get("publication_keys") or [
+            "publication_date",
+            "published",
+            "pub_date",
+            "date",
+            "#date+published",
+        ]
+        source_url_keys = source.get("source_url_keys") or ["source", "source_url", "url"]
+
+        publisher = source.get("publisher", "IPC")
+        source_type = source.get("source_type", "official")
+        source_url_fallback = source.get("url", "")
+        source_key = _series_source_key(source)
+
+        for record in frame.df.to_dict(orient="records"):
+            iso_raw = _best_of(record, frame, country_keys)
+            iso = str(iso_raw or "").strip().upper()
+            if len(iso) == 2:
+                iso = ""  # skip alpha-2 until population join is defined
+            if not iso or iso not in iso3_to_name:
+                continue
+
+            start_val = _best_of(record, frame, period_start_keys)
+            end_val = _best_of(record, frame, period_end_keys)
+            months = _expand_period(start_val, end_val)
+            if not months:
+                continue
+
+            phase3_val = _best_of(record, frame, phase3p_keys)
+            phase3 = _parse_people(phase3_val)
+            if phase3 is None:
+                continue
+
+            phase4 = _parse_people(_best_of(record, frame, phase4p_keys))
+            phase5 = _parse_people(_best_of(record, frame, phase5_keys))
+
+            drivers_parts: List[str] = []
+            for key in drivers_keys:
+                val = record.get(frame.column_map.get(_normalise_key(key), key))
+                if val:
+                    drivers_parts.append(str(val))
+            drivers_text = ", ".join(part for part in ("; ".join(drivers_parts)).split(";")) if drivers_parts else ""
+
+            hazard_code, hazard_label, hazard_class = _resolve_hazard(
+                drivers_text,
+                cfg=cfg,
+                hazard_lookup=hazard_lookup,
+                default_key=default_hazard_key,
+            )
+
+            doc_title = str(_best_of(record, frame, title_keys) or source.get("name") or "IPC")
+            publication_date = _normalise_date(_best_of(record, frame, publication_keys))
+            source_url = str(_best_of(record, frame, source_url_keys) or source_url_fallback)
+
+            definition = _definition_from_row(
+                period_start=_normalise_date(start_val),
+                period_end=_normalise_date(end_val),
+                phase4=phase4,
+                phase5=phase5,
+                drivers=drivers_text,
+            )
+
+            for month in months:
+                key = (iso, hazard_code, month, source_key)
+                if key not in stock_rows:
+                    stock_rows[key] = MonthlyRecord(
+                        iso3=iso,
+                        country_name=iso3_to_name.get(iso, iso),
+                        hazard_code=hazard_code,
+                        hazard_label=hazard_label,
+                        hazard_class=hazard_class,
+                        month=month,
+                        value=0.0,
+                        source_key=source_key,
+                        source_url=source_url,
+                        doc_title=doc_title,
+                        publication_date=publication_date,
+                        definition_parts=[],
+                        drivers_text=drivers_text,
+                        method_notes="",
+                        publisher=publisher,
+                        source_type=source_type,
+                    )
+                stock_rec = stock_rows[key]
+                stock_rec.value += phase3
+                stock_rec.source_url = stock_rec.source_url or source_url
+                stock_rec.doc_title = stock_rec.doc_title or doc_title
+                stock_rec.publication_date = stock_rec.publication_date or publication_date
+                stock_rec.definition_parts = _merge_definition(stock_rec.definition_parts, definition)
+
+    if not stock_rows:
+        return [], []
+
+    ingested_at = _ingested_timestamp()
+    stock_output: List[Dict[str, Any]] = []
+
+    for key in sorted(stock_rows.keys()):
+        record = stock_rows[key]
+        if not emit_stock:
+            continue
+        value = float(record.value)
+        if value <= 0:
+            continue
+        event_id = _make_event_id(
+            record.iso3,
+            record.hazard_code,
+            "in_need",
+            record.month,
+            value,
+            record.source_url,
+        )
+        stock_output.append(
+            {
+                "event_id": event_id,
+                "country_name": record.country_name,
+                "iso3": record.iso3,
+                "hazard_code": record.hazard_code,
+                "hazard_label": record.hazard_label,
+                "hazard_class": record.hazard_class,
+                "metric": "in_need",
+                "series_semantics": SERIES_STOCK,
+                "value": round(value, 3),
+                "unit": "persons",
+                "as_of_date": record.month,
+                "publication_date": record.publication_date,
+                "publisher": record.publisher,
+                "source_type": record.source_type,
+                "source_url": record.source_url,
+                "doc_title": record.doc_title or "IPC Acute Food Insecurity",
+                "definition_text": " ".join(record.definition_parts).strip(),
+                "method": "IPC; Phase 3+ stock; period→month expansion; national sum",
+                "confidence": "",
+                "revision": "",
+                "ingested_at": ingested_at,
+                "_source_key": record.source_key,
+            }
+        )
+
+    incident_output: List[Dict[str, Any]] = []
+    if emit_incident:
+        grouped: Dict[Tuple[str, str, str], List[Dict[str, Any]]] = {}
+        for row in stock_output:
+            key = (row["iso3"], row["hazard_code"], row.get("_source_key", ""))
+            grouped.setdefault(key, []).append(row)
+        for group_rows in grouped.values():
+            group_rows.sort(key=lambda r: r["as_of_date"])
+            prev_value: Optional[float] = None
+            for idx, row in enumerate(group_rows):
+                current_value = float(row["value"])
+                if idx == 0:
+                    if include_first_delta and current_value > 0:
+                        delta = current_value
+                    else:
+                        prev_value = current_value
+                        continue
+                else:
+                    delta = max(current_value - (prev_value or 0.0), 0.0)
+                prev_value = current_value
+                if delta <= 0:
+                    continue
+                event_id = _make_event_id(
+                    row["iso3"],
+                    row["hazard_code"],
+                    "in_need",
+                    row["as_of_date"],
+                    delta,
+                    row.get("source_url", ""),
+                )
+                incident_output.append(
+                    {
+                        **{k: v for k, v in row.items() if k not in {"value", "series_semantics", "event_id", "_source_key"}},
+                        "event_id": event_id,
+                        "series_semantics": SERIES_INCIDENT,
+                        "value": round(delta, 3),
+                        "method": "IPC; Phase 3+ stock; period→month expansion; national sum; incident=new PIN (MoM positive delta)",
+                        "_source_key": row.get("_source_key", ""),
+                    }
+                )
+
+    for row in stock_output + incident_output:
+        row.pop("_source_key", None)
+
+    return stock_output, incident_output
+
+
+def _make_event_id(iso3: str, hazard_code: str, metric: str, month: str, value: float, source_url: str) -> str:
+    digest = _digest([iso3, hazard_code, metric, month, f"{value:.3f}", source_url])
+    year, month_part = month.split("-", 1)
+    return f"{iso3}-IPC-{hazard_code}-{metric}-{year}-{month_part}-{digest}"
+
+
+def _write_rows(rows: Sequence[Dict[str, Any]], *, path: Path) -> None:
+    df = pd.DataFrame(rows, columns=CANONICAL_HEADERS)
+    if not rows:
+        df = pd.DataFrame(columns=CANONICAL_HEADERS)
+    else:
+        for col in CANONICAL_HEADERS:
+            if col not in df.columns:
+                df[col] = ""
+        df = df[CANONICAL_HEADERS]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(path, index=False)
+
+
+def _write_header_only(path: Path) -> None:
+    _write_rows([], path=path)
+
+
+def main() -> bool:
+    if os.getenv("RESOLVER_SKIP_IPC") == "1":
+        dbg("RESOLVER_SKIP_IPC=1 → writing header only")
+        _write_header_only(OUT_PATH)
+        return False
+
+    try:
+        cfg = load_config()
+    except Exception as exc:
+        dbg(f"failed to load config: {exc}")
+        _write_header_only(OUT_PATH)
+        return False
+
+    emit_stock = _env_bool("IPC_EMIT_STOCK", bool(cfg.get("emit_stock", True)))
+    emit_incident = _env_bool("IPC_EMIT_INCIDENT", bool(cfg.get("emit_incident", True)))
+    include_first_delta = _env_bool(
+        "IPC_INCLUDE_FIRST_MONTH_DELTA", bool(cfg.get("include_first_month_delta", False))
+    )
+
+    try:
+        stock_rows, incident_rows = _collect_rows(
+            cfg=cfg,
+            emit_stock=emit_stock,
+            emit_incident=emit_incident,
+            include_first_delta=include_first_delta,
+        )
+    except Exception as exc:
+        dbg(f"IPC processing failed: {exc}")
+        _write_header_only(OUT_PATH)
+        return False
+
+    rows: List[Dict[str, Any]] = []
+    rows.extend(stock_rows)
+    rows.extend(incident_rows)
+
+    max_results = _env_int("RESOLVER_MAX_RESULTS")
+    if max_results is not None:
+        rows = rows[:max_results]
+
+    _write_rows(rows, path=OUT_PATH)
+    print(f"wrote {OUT_PATH}")
+    return bool(rows)
+
+
+if __name__ == "__main__":
+    main()

--- a/resolver/ingestion/run_all_stubs.py
+++ b/resolver/ingestion/run_all_stubs.py
@@ -14,6 +14,7 @@ STUBS = [
     "unhcr_odp_client.py",    # real connector (fail-soft/skip-capable)
     "dtm_client.py",          # real connector (fail-soft/skip-capable)
     "who_phe_client.py",      # real connector (fail-soft/skip-capable)
+    "ipc_client.py",          # real connector (fail-soft/skip-capable)
     "reliefweb_client.py",    # real connector (may be skipped via env)
     "hdx_client.py",          # real connector (fail-soft/skip-capable)
     "dtm_stub.py",
@@ -139,6 +140,25 @@ def main():
                 continue
             if not ok:
                 print("WHO PHE connector produced no rows", file=sys.stderr)
+            continue
+
+        if script == "ipc_client.py":
+            if env.get("RESOLVER_SKIP_IPC") == "1":
+                print("RESOLVER_SKIP_IPC=1 — IPC connector will be skipped")
+                continue
+            if not path.exists():
+                print("ipc_client.py missing; skipping IPC connector", file=sys.stderr)
+                continue
+            print("==> running ipc_client.py")
+            try:
+                mod = importlib.import_module("resolver.ingestion.ipc_client")
+                ok = mod.main()
+            except Exception as exc:
+                print(f"IPC connector raised {exc}; continuing with other sources…", file=sys.stderr)
+                failed += 1
+                continue
+            if not ok:
+                print("IPC connector produced no rows", file=sys.stderr)
             continue
 
         if script == "hdx_client.py":

--- a/resolver/tests/test_connectors_headers.py
+++ b/resolver/tests/test_connectors_headers.py
@@ -70,3 +70,12 @@ def test_dtm_header_written(tmp_path, monkeypatch):
     with open(dtm_client.OUT_PATH, newline="", encoding="utf-8") as f:
         row = next(csv.reader(f))
     assert row == dtm_client.CANONICAL_HEADERS
+
+
+def test_ipc_header_written(tmp_path, monkeypatch):
+    monkeypatch.setenv("RESOLVER_SKIP_IPC", "1")
+    mod = importlib.import_module("resolver.ingestion.ipc_client")
+    tmp_out = Path(tmp_path) / "ipc.csv"
+    mod.OUT_PATH = tmp_out
+    mod.main()
+    _assert_header(tmp_out)

--- a/resolver/tests/test_ipc_delta_logic.py
+++ b/resolver/tests/test_ipc_delta_logic.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+
+import pandas as pd
+
+from resolver.ingestion import ipc_client
+
+
+def _base_config(rows):
+    return {
+        "sources": [
+            {
+                "name": "ipc_delta_test",
+                "kind": "inline",
+                "data": rows,
+                "country_keys": ["iso3"],
+                "period_start_keys": ["period_start"],
+                "period_end_keys": ["period_end"],
+                "phase3p_keys": ["phase3plus"],
+                "drivers_keys": ["drivers"],
+                "publisher": "IPC",
+                "source_type": "official",
+            }
+        ],
+        "shock_keywords": {
+            "drought": ["drought"],
+        },
+        "emit_stock": True,
+        "emit_incident": True,
+        "include_first_month_delta": False,
+        "default_hazard": "multi",
+    }
+
+
+def test_ipc_delta_clips_negatives(tmp_path, monkeypatch):
+    config = _base_config(
+        [
+            {
+                "iso3": "ETH",
+                "period_start": "2025-01-01",
+                "period_end": "2025-01-31",
+                "phase3plus": "100000",
+                "drivers": "drought",
+            },
+            {
+                "iso3": "ETH",
+                "period_start": "2025-02-01",
+                "period_end": "2025-02-28",
+                "phase3plus": "120000",
+                "drivers": "drought",
+            },
+            {
+                "iso3": "ETH",
+                "period_start": "2025-03-01",
+                "period_end": "2025-03-31",
+                "phase3plus": "110000",
+                "drivers": "drought",
+            },
+        ]
+    )
+
+    out_path = Path(tmp_path) / "ipc.csv"
+    monkeypatch.delenv("RESOLVER_SKIP_IPC", raising=False)
+    monkeypatch.setattr(ipc_client, "OUT_PATH", out_path)
+    monkeypatch.setattr(ipc_client, "load_config", lambda: config)
+
+    ipc_client.main()
+
+    df = pd.read_csv(out_path)
+    incident = df[df["series_semantics"] == "incident"].copy()
+
+    assert list(incident["as_of_date"]) == ["2025-02"]
+    assert incident.iloc[0]["value"] == 20000.0

--- a/resolver/tests/test_ipc_period_to_month.py
+++ b/resolver/tests/test_ipc_period_to_month.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+import pandas as pd
+
+from resolver.ingestion import ipc_client
+
+
+def _base_config(rows):
+    return {
+        "sources": [
+            {
+                "name": "ipc_test",
+                "kind": "inline",
+                "data": rows,
+                "country_keys": ["iso3"],
+                "period_start_keys": ["period_start"],
+                "period_end_keys": ["period_end"],
+                "phase3p_keys": ["phase3plus"],
+                "drivers_keys": ["drivers"],
+                "publisher": "IPC",
+                "source_type": "official",
+            }
+        ],
+        "shock_keywords": {
+            "drought": ["drought"],
+        },
+        "emit_stock": True,
+        "emit_incident": True,
+        "include_first_month_delta": False,
+        "default_hazard": "multi",
+    }
+
+
+def test_ipc_period_to_month_expansion(tmp_path, monkeypatch):
+    config = _base_config(
+        [
+            {
+                "iso3": "SDN",
+                "period_start": "2025-01-01",
+                "period_end": "2025-03-31",
+                "phase3plus": "100000",
+                "drivers": "drought",
+            }
+        ]
+    )
+
+    out_path = Path(tmp_path) / "ipc.csv"
+    monkeypatch.delenv("RESOLVER_SKIP_IPC", raising=False)
+    monkeypatch.setattr(ipc_client, "OUT_PATH", out_path)
+    monkeypatch.setattr(ipc_client, "load_config", lambda: config)
+
+    assert ipc_client.main() is True
+
+    df = pd.read_csv(out_path)
+    stock = df[df["series_semantics"] == "stock"].copy()
+    assert set(stock["as_of_date"]) == {"2025-01", "2025-02", "2025-03"}
+    assert all(stock["value"].astype(float) == 100000.0)

--- a/resolver/tests/test_ipc_shock_mapping.py
+++ b/resolver/tests/test_ipc_shock_mapping.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+
+import pandas as pd
+
+from resolver.ingestion import ipc_client
+
+
+def _config(rows):
+    return {
+        "sources": [
+            {
+                "name": "ipc_shock_test",
+                "kind": "inline",
+                "data": rows,
+                "country_keys": ["iso3"],
+                "period_start_keys": ["period_start"],
+                "period_end_keys": ["period_end"],
+                "phase3p_keys": ["phase3plus"],
+                "drivers_keys": ["drivers"],
+                "publisher": "IPC",
+                "source_type": "official",
+            }
+        ],
+        "shock_keywords": {
+            "drought": ["drought"],
+            "armed_conflict_escalation": ["conflict", "violence"],
+            "economic_crisis": ["economic", "inflation"],
+        },
+        "emit_stock": True,
+        "emit_incident": False,
+        "include_first_month_delta": False,
+        "default_hazard": "multi",
+    }
+
+
+def test_ipc_shock_keyword_mapping(tmp_path, monkeypatch):
+    config = _config(
+        [
+            {
+                "iso3": "KEN",
+                "period_start": "2025-01-01",
+                "period_end": "2025-01-31",
+                "phase3plus": "50000",
+                "drivers": "Drought; conflict",
+            },
+            {
+                "iso3": "KEN",
+                "period_start": "2025-02-01",
+                "period_end": "2025-02-28",
+                "phase3plus": "60000",
+                "drivers": "Economic shock",
+            },
+            {
+                "iso3": "KEN",
+                "period_start": "2025-03-01",
+                "period_end": "2025-03-31",
+                "phase3plus": "70000",
+                "drivers": "",
+            },
+        ]
+    )
+
+    out_path = Path(tmp_path) / "ipc.csv"
+    monkeypatch.delenv("RESOLVER_SKIP_IPC", raising=False)
+    monkeypatch.setattr(ipc_client, "OUT_PATH", out_path)
+    monkeypatch.setattr(ipc_client, "load_config", lambda: config)
+
+    ipc_client.main()
+
+    df = pd.read_csv(out_path)
+    stock = df[df["series_semantics"] == "stock"].sort_values("as_of_date").reset_index(drop=True)
+
+    assert list(stock["hazard_code"]) == ["DR", "EC", "multi"]
+    assert stock.iloc[2]["hazard_label"] == "Multi-driver Food Insecurity"

--- a/resolver/tools/precedence_config.yml
+++ b/resolver/tools/precedence_config.yml
@@ -1,6 +1,10 @@
 # Policy knobs (kept here so we don't hardcode in code)
 metric_preference: [in_need, affected]   # PIN first, else PA
-source_precedence:                       # highest → lowest
+tiers:
+  - ["unhcr_api", "unhcr_odp", "ifrc_go", "who", "ipc"]
+  - ["dtm", "hdx"]
+  - ["reliefweb", "media"]
+source_precedence:                       # highest → lowest (legacy policy tiers)
   - inter_agency_plan
   - ifrc_or_gov_sitrep
   - un_cluster_snapshot
@@ -52,6 +56,7 @@ cutoff:
   lag_days_allowed: 7
 
 lags:
+  ipc: 7d
   who: 2d
   dtm: 2d
   hdx: 3d


### PR DESCRIPTION
## Summary
- add a real IPC ingestion client that expands periods to monthly stock rows and derives incident deltas
- provide IPC connector configuration, hook it into the ingestion runner, and update precedence tiers and lags
- add regression tests for IPC monthly expansion, delta clipping, shock keyword mapping, and header-only skip mode

## Testing
- pytest resolver/tests/test_ipc_period_to_month.py resolver/tests/test_ipc_delta_logic.py resolver/tests/test_ipc_shock_mapping.py resolver/tests/test_connectors_headers.py

------
https://chatgpt.com/codex/tasks/task_e_68de77648954832c91a56c5752a1497d