### PR TITLE
Add EM-DAT connector with monthly allocation

### DIFF
--- a/resolver/data/shocks.csv
+++ b/resolver/data/shocks.csv
@@ -3,6 +3,11 @@ FL,Flood,natural
 DR,Drought,natural
 TC,Tropical Cyclone,natural
 HW,Heat Wave,natural
+CW,Cold Wave,natural
+WF,Wildfire,natural
+LS,Landslide,natural
+VO,Volcanic Activity,natural
+EQ,Earthquake,natural
 ACO,Armed Conflict - Onset,human-induced
 ACE,Armed Conflict - Escalation,human-induced
 ACC,Armed Conflict - Cessation,human-induced
@@ -10,3 +15,5 @@ DI,Displacement Influx (cross-border from neighbouring country),human-induced
 CU,Civil Unrest,human-induced
 EC,Economic Crisis,human-induced
 PHE,Public Health Emergency,epidemic
+OT,Other / Technological,other
+MULTI,Multi-hazard,multi

--- a/resolver/ingestion/README.md
+++ b/resolver/ingestion/README.md
@@ -32,6 +32,12 @@ Each connector:
 - Reads `resolver/data/countries.csv` and `resolver/data/shocks.csv`
 - Produces `resolver/staging/<source>.csv` using the exporter’s expected columns
 
+### EM-DAT allocation example
+
+- Event spans **15 Jan – 10 Mar 2025** with **9,000 Total Affected** → prorata policy yields
+  `2025-01: 2,782`, `2025-02: 4,582`, `2025-03: 1,636` (days-in-month share; last bucket keeps the remainder).
+- Start-month policy instead puts the full **9,000** on `2025-01` and omits later months.
+
 ## Run all stubs
 
 ```bash

--- a/resolver/ingestion/config/emdat.yml
+++ b/resolver/ingestion/config/emdat.yml
@@ -1,0 +1,32 @@
+sources:
+  - name: emdat_events
+    kind: csv
+    url: https://data.humdata.org/dataset/emdat-example.csv
+    country_keys: ["ISO", "iso3", "#country+code", "Country ISO3", "Country"]
+    start_date_keys: ["Start Date", "Start", "Began", "#date+start"]
+    end_date_keys: ["End Date", "End", "Finished", "#date+end"]
+    type_keys: ["Disaster Type", "Type"]
+    subtype_keys: ["Disaster Subtype", "Subtype"]
+    total_affected_keys: ["Total Affected", "#affected+total", "Affected Total"]
+    affected_keys: ["Affected", "#affected"]
+    injured_keys: ["Injured", "#affected+injured"]
+    homeless_keys: ["Homeless", "#affected+homeless"]
+    id_keys: ["Dis No", "Event ID", "EMDAT ID"]
+    title_keys: ["Event Name", "Title"]
+    publisher: "CRED/EM-DAT"
+    source_type: "other"
+prefer_hxl: true
+allocation_policy: prorata
+shock_map:
+  flood: ["Flood"]
+  drought: ["Drought"]
+  tropical_cyclone: ["Storm", "Tropical cyclone", "Hurricane", "Typhoon"]
+  heat_wave: ["Heat wave", "Extreme temperature", "Heat"]
+  cold_wave: ["Cold wave", "Extreme cold", "Cold"]
+  wildfire: ["Wildfire", "Forest fire", "Fire"]
+  earthquake: ["Earthquake", "Seismic"]
+  landslide: ["Landslide"]
+  volcano: ["Volcanic activity", "Volcano"]
+  phe: ["Epidemic", "Infectious disease", "Outbreak"]
+  other: ["Industrial accident", "Technological", "Transport"]
+default_hazard: other

--- a/resolver/ingestion/emdat_client.py
+++ b/resolver/ingestion/emdat_client.py
@@ -1,0 +1,640 @@
+#!/usr/bin/env python3
+"""EM-DAT connector that allocates event impacts to monthly incident totals."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, MutableMapping, Optional, Sequence, Tuple
+
+import pandas as pd
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA = ROOT / "data"
+STAGING = ROOT / "staging"
+CONFIG = ROOT / "ingestion" / "config" / "emdat.yml"
+
+COUNTRIES = DATA / "countries.csv"
+SHOCKS = DATA / "shocks.csv"
+
+OUT_DIR = STAGING
+OUT_PATH = OUT_DIR / "emdat.csv"
+
+CANONICAL_HEADERS = [
+    "event_id",
+    "country_name",
+    "iso3",
+    "hazard_code",
+    "hazard_label",
+    "hazard_class",
+    "metric",
+    "series_semantics",
+    "value",
+    "unit",
+    "as_of_date",
+    "publication_date",
+    "publisher",
+    "source_type",
+    "source_url",
+    "doc_title",
+    "definition_text",
+    "method",
+    "confidence",
+    "revision",
+    "ingested_at",
+]
+
+SERIES_SEMANTICS = "incident"
+
+HAZARD_KEY_TO_CODE = {
+    "flood": "FL",
+    "drought": "DR",
+    "tropical_cyclone": "TC",
+    "heat_wave": "HW",
+    "cold_wave": "CW",
+    "wildfire": "WF",
+    "earthquake": "EQ",
+    "landslide": "LS",
+    "volcano": "VO",
+    "phe": "PHE",
+    "other": "OT",
+    "multi": "MULTI",
+}
+
+DEFAULT_METHOD_PREFIX = "EM-DAT event→month allocation"
+DEFAULT_DEFINITION_PRORATA = (
+    "Total affected people from EM-DAT events allocated to each overlapping month "
+    "proportionally by days (incident new affected)."
+)
+DEFAULT_DEFINITION_START = (
+    "Total affected people from EM-DAT events allocated entirely to the event start month "
+    "(incident new affected)."
+)
+
+DEBUG = os.getenv("RESOLVER_DEBUG", "0") == "1"
+
+
+@dataclass(frozen=True)
+class Hazard:
+    code: str
+    label: str
+    hazard_class: str
+
+
+def dbg(message: str) -> None:
+    if DEBUG:
+        print(f"[emdat] {message}")
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _env_int(name: str) -> Optional[int]:
+    value = os.getenv(name)
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def load_config() -> Dict[str, Any]:
+    if not CONFIG.exists():
+        return {"sources": []}
+    with open(CONFIG, "r", encoding="utf-8") as fp:
+        cfg = yaml.safe_load(fp) or {}
+    cfg.setdefault("sources", [])
+    return cfg
+
+
+def load_registries() -> Tuple[Dict[str, str], Dict[str, str], Dict[str, Hazard]]:
+    countries_df = pd.read_csv(COUNTRIES, dtype=str).fillna("")
+    shocks_df = pd.read_csv(SHOCKS, dtype=str).fillna("")
+
+    iso3_to_name = {}
+    name_to_iso3 = {}
+    for row in countries_df.itertuples(index=False):
+        iso = str(row.iso3).strip().upper()
+        name = str(row.country_name).strip()
+        if not iso:
+            continue
+        iso3_to_name[iso] = name
+        key = _normalise_text(name)
+        if key:
+            name_to_iso3[key] = iso
+
+    hazard_lookup: Dict[str, Hazard] = {}
+    for row in shocks_df.itertuples(index=False):
+        code = str(row.hazard_code).strip().upper()
+        hazard_lookup[code] = Hazard(
+            code=code,
+            label=str(row.hazard_label).strip(),
+            hazard_class=str(row.hazard_class).strip(),
+        )
+
+    return iso3_to_name, name_to_iso3, hazard_lookup
+
+
+def _normalise_text(value: Any) -> str:
+    return "".join(ch for ch in str(value or "").strip().lower() if ch.isalnum())
+
+
+def _read_source_frame(
+    source: MutableMapping[str, Any],
+    *,
+    prefer_hxl: bool,
+) -> Tuple[pd.DataFrame, Dict[int, str]]:
+    kind = str(source.get("kind", "csv")).strip().lower() or "csv"
+    url = source.get("url")
+    if not url:
+        raise ValueError("source url missing")
+
+    hxl_tags: Dict[int, str] = {}
+    if kind == "xlsx":
+        frame = pd.read_excel(url, dtype=str, keep_default_na=False)
+    else:
+        frame = pd.read_csv(url, dtype=str, keep_default_na=False)
+
+    frame = frame.fillna("")
+    if frame.empty:
+        return frame, hxl_tags
+
+    first_row = frame.iloc[0]
+    if prefer_hxl and any(str(val).strip().startswith("#") for val in first_row):
+        hxl_tags = {idx: str(val).strip() for idx, val in enumerate(first_row)}
+        frame = frame.iloc[1:].reset_index(drop=True)
+
+    return frame, hxl_tags
+
+
+def _match_column(
+    frame: pd.DataFrame,
+    candidates: Sequence[str],
+    hxl_tags: Dict[int, str],
+    prefer_hxl: bool,
+) -> Optional[str]:
+    if not candidates:
+        return None
+    normalised_candidates = [_normalise_text(cand) for cand in candidates if cand]
+    if not normalised_candidates:
+        return None
+
+    def _match_from_tags() -> Optional[str]:
+        for idx, tag in hxl_tags.items():
+            norm_tag = _normalise_text(tag)
+            if norm_tag in normalised_candidates and idx < len(frame.columns):
+                return frame.columns[idx]
+        return None
+
+    if prefer_hxl and hxl_tags:
+        matched = _match_from_tags()
+        if matched:
+            return matched
+
+    for column in frame.columns:
+        norm = _normalise_text(column)
+        if norm in normalised_candidates:
+            return column
+
+    if not prefer_hxl and hxl_tags:
+        matched = _match_from_tags()
+        if matched:
+            return matched
+
+    return None
+
+
+def _parse_date(value: Any) -> Optional[date]:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        parsed = pd.to_datetime(text, errors="coerce")
+    except Exception:
+        parsed = pd.NaT
+    if pd.isna(parsed):
+        return None
+    return parsed.date()
+
+
+def _parse_persons(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    cleaned = "".join(ch for ch in text if ch.isdigit() or ch in {".", "-"})
+    if not cleaned:
+        return None
+    try:
+        number = float(cleaned)
+    except ValueError:
+        return None
+    if number <= 0:
+        return None
+    return int(round(number))
+
+
+def _normalise_iso3(
+    value: Any,
+    *,
+    iso3_to_name: Dict[str, str],
+    name_to_iso3: Dict[str, str],
+) -> Optional[str]:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    upper = text.upper()
+    if len(upper) == 3 and upper.isalpha() and upper in iso3_to_name:
+        return upper
+    key = _normalise_text(text)
+    return name_to_iso3.get(key)
+
+
+def _next_month(value: date) -> date:
+    if value.month == 12:
+        return date(value.year + 1, 1, 1)
+    return date(value.year, value.month + 1, 1)
+
+
+def _month_end(value: date) -> date:
+    return _next_month(value) - timedelta(days=1)
+
+
+def _iter_month_segments(start: date, end: date) -> Iterable[Tuple[str, int]]:
+    if end < start:
+        end = start
+    current = date(start.year, start.month, 1)
+    segments: List[Tuple[str, int]] = []
+    while current <= end:
+        month_end = _month_end(current)
+        seg_start = start if current < start else current
+        seg_end = end if month_end > end else month_end
+        if seg_end >= seg_start:
+            month_key = f"{current.year:04d}-{current.month:02d}"
+            days = (seg_end - seg_start).days + 1
+            segments.append((month_key, days))
+        current = _next_month(current)
+    return segments
+
+
+def _allocate_event(
+    start: date,
+    end: date,
+    total: int,
+    *,
+    policy: str,
+) -> List[Tuple[str, int]]:
+    if total <= 0:
+        return []
+    if policy == "start":
+        month_key = f"{start.year:04d}-{start.month:02d}"
+        return [(month_key, int(total))]
+
+    segments = list(_iter_month_segments(start, end))
+    if not segments:
+        month_key = f"{start.year:04d}-{start.month:02d}"
+        return [(month_key, int(total))]
+
+    total_days = sum(days for _, days in segments)
+    if total_days <= 0:
+        month_key = f"{start.year:04d}-{start.month:02d}"
+        return [(month_key, int(total))]
+
+    allocations: List[Tuple[str, int]] = []
+    running = 0
+    for idx, (month_key, days) in enumerate(segments):
+        last = idx == len(segments) - 1
+        if last:
+            value = total - running
+        else:
+            raw = total * days / total_days
+            value = int(round(raw))
+            if running + value > total:
+                value = max(total - running, 0)
+            running += value
+        if last:
+            running += value
+        value = int(value)
+        if value > 0:
+            allocations.append((month_key, value))
+    return allocations
+
+
+def _infer_hazard_key(
+    type_value: Any,
+    subtype_value: Any,
+    *,
+    shock_map: Dict[str, Sequence[str]],
+    default_key: str,
+) -> str:
+    texts = [str(type_value or "").strip(), str(subtype_value or "").strip()]
+    norm_texts = [_normalise_text(text) for text in texts if text]
+
+    for hazard_key, keywords in shock_map.items():
+        targets = [_normalise_text(keyword) for keyword in keywords if keyword]
+        if not targets:
+            continue
+        for candidate in norm_texts:
+            for target in targets:
+                if not target:
+                    continue
+                if candidate == target or candidate.startswith(target) or target in candidate:
+                    return hazard_key
+
+    return default_key
+
+
+def _resolve_hazard(
+    hazard_key: str,
+    *,
+    hazard_lookup: Dict[str, Hazard],
+) -> Hazard:
+    code = HAZARD_KEY_TO_CODE.get(hazard_key, HAZARD_KEY_TO_CODE.get("other", "OT"))
+    if code in hazard_lookup:
+        return hazard_lookup[code]
+    label = hazard_key.replace("_", " ").title() if hazard_key else "Other"
+    return Hazard(code=code, label=label, hazard_class="other")
+
+
+def _build_event_id(
+    iso3: str,
+    hazard_code: str,
+    month: str,
+    value: int,
+    source_url: str,
+    dis_refs: Sequence[str],
+) -> str:
+    digest_input = "|".join([
+        iso3,
+        hazard_code,
+        month,
+        str(value),
+        source_url,
+        ",".join(sorted({ref for ref in dis_refs if ref})),
+    ])
+    digest = hashlib.sha256(digest_input.encode("utf-8")).hexdigest()[:12]
+    year, month_part = month.split("-")
+    return f"{iso3}-EMDAT-{hazard_code}-affected-{year}-{month_part}-{digest}"
+
+
+def _write_header_only(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8", newline="") as fp:
+        fp.write(",".join(CANONICAL_HEADERS) + "\n")
+
+
+def _write_rows(rows: Sequence[Sequence[Any]], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    frame = pd.DataFrame(rows, columns=CANONICAL_HEADERS)
+    frame.to_csv(path, index=False)
+
+
+def main() -> bool:
+    if _env_bool("RESOLVER_SKIP_EMDAT", False):
+        dbg("RESOLVER_SKIP_EMDAT=1 — writing header only")
+        _write_header_only(OUT_PATH)
+        return False
+
+    try:
+        cfg = load_config()
+    except Exception as exc:  # pragma: no cover - defensive
+        dbg(f"failed to load config: {exc}")
+        _write_header_only(OUT_PATH)
+        return False
+
+    sources = cfg.get("sources", [])
+    if not sources:
+        dbg("no EM-DAT sources configured")
+        _write_header_only(OUT_PATH)
+        return False
+
+    try:
+        iso3_to_name, name_to_iso3, hazard_lookup = load_registries()
+    except Exception as exc:  # pragma: no cover - defensive
+        dbg(f"failed to load registries: {exc}")
+        _write_header_only(OUT_PATH)
+        return False
+
+    prefer_hxl = bool(cfg.get("prefer_hxl", False))
+    alloc_policy = os.getenv("EMDAT_ALLOC_POLICY", str(cfg.get("allocation_policy", "prorata")))
+    alloc_policy = alloc_policy.strip().lower() or "prorata"
+    if alloc_policy not in {"prorata", "start"}:
+        alloc_policy = "prorata"
+
+    definition_text = (
+        DEFAULT_DEFINITION_PRORATA if alloc_policy == "prorata" else DEFAULT_DEFINITION_START
+    )
+    method = f"{DEFAULT_METHOD_PREFIX}; {alloc_policy}"
+
+    default_hazard_key = str(cfg.get("default_hazard", "other")).strip().lower() or "other"
+    shock_map = cfg.get("shock_map", {}) or {}
+
+    allocations: List[Dict[str, Any]] = []
+    seen_events: set[Tuple[str, str, date, date]] = set()
+
+    for source in sources:
+        try:
+            frame, hxl_tags = _read_source_frame(source, prefer_hxl=prefer_hxl)
+        except Exception as exc:
+            dbg(f"failed to load source {source.get('name')}: {exc}")
+            continue
+
+        if frame.empty:
+            continue
+
+        country_col = _match_column(frame, source.get("country_keys", []), hxl_tags, prefer_hxl)
+        start_col = _match_column(frame, source.get("start_date_keys", []), hxl_tags, prefer_hxl)
+        end_col = _match_column(frame, source.get("end_date_keys", []), hxl_tags, prefer_hxl)
+        type_col = _match_column(frame, source.get("type_keys", []), hxl_tags, prefer_hxl)
+        subtype_col = _match_column(frame, source.get("subtype_keys", []), hxl_tags, prefer_hxl)
+        total_col = _match_column(frame, source.get("total_affected_keys", []), hxl_tags, prefer_hxl)
+        affected_col = _match_column(frame, source.get("affected_keys", []), hxl_tags, prefer_hxl)
+        injured_col = _match_column(frame, source.get("injured_keys", []), hxl_tags, prefer_hxl)
+        homeless_col = _match_column(frame, source.get("homeless_keys", []), hxl_tags, prefer_hxl)
+        id_col = _match_column(frame, source.get("id_keys", []), hxl_tags, prefer_hxl)
+        title_col = _match_column(frame, source.get("title_keys", []), hxl_tags, prefer_hxl)
+
+        dedup_cols = [
+            col
+            for col in [country_col, start_col, end_col, id_col, type_col, subtype_col, total_col]
+            if col
+        ]
+        if dedup_cols:
+            frame = frame.drop_duplicates(subset=dedup_cols)
+
+        publisher = str(source.get("publisher", cfg.get("publisher", "CRED/EM-DAT")))
+        source_type = str(source.get("source_type", cfg.get("source_type", "other")))
+        source_url = str(source.get("url", ""))
+        doc_title = source.get("doc_title") or f"{source.get('name', 'EM-DAT')} event table"
+
+        for record in frame.to_dict("records"):
+            iso_candidate = record.get(country_col) if country_col else None
+            iso3 = _normalise_iso3(iso_candidate, iso3_to_name=iso3_to_name, name_to_iso3=name_to_iso3)
+            if not iso3:
+                continue
+
+            start_date = _parse_date(record.get(start_col) if start_col else None)
+            if not start_date:
+                continue
+            end_date = _parse_date(record.get(end_col) if end_col else None) or start_date
+
+            dis_no = str(record.get(id_col, "")) if id_col else ""
+            event_name = str(record.get(title_col, "")) if title_col else ""
+
+            hazard_key = _infer_hazard_key(
+                record.get(type_col) if type_col else "",
+                record.get(subtype_col) if subtype_col else "",
+                shock_map=shock_map,
+                default_key=default_hazard_key,
+            )
+            hazard = _resolve_hazard(hazard_key, hazard_lookup=hazard_lookup)
+
+            total_value = None
+            if total_col:
+                total_value = _parse_persons(record.get(total_col))
+            if total_value is None and affected_col:
+                total_value = _parse_persons(record.get(affected_col))
+            if total_value is None:
+                components: List[int] = []
+                for col in (affected_col, injured_col, homeless_col):
+                    if not col:
+                        continue
+                    parsed = _parse_persons(record.get(col))
+                    if parsed is not None:
+                        components.append(parsed)
+                if components:
+                    total_value = int(sum(components)) if sum(components) > 0 else None
+
+            if total_value is None or total_value <= 0:
+                continue
+
+            event_key = (iso3, dis_no, start_date, end_date)
+            if dis_no and event_key in seen_events:
+                continue
+            if dis_no:
+                seen_events.add(event_key)
+
+            month_allocations = _allocate_event(start_date, end_date, int(total_value), policy=alloc_policy)
+            for month, value in month_allocations:
+                if value <= 0:
+                    continue
+                allocations.append(
+                    {
+                        "iso3": iso3,
+                        "hazard": hazard,
+                        "month": month,
+                        "value": int(value),
+                        "publisher": publisher,
+                        "source_type": source_type,
+                        "source_url": source_url,
+                        "doc_title": doc_title,
+                        "dis_ref": dis_no or event_name or f"{iso3}-{month}",
+                        "event_name": event_name,
+                    }
+                )
+
+    if not allocations:
+        dbg("no allocations generated")
+        _write_header_only(OUT_PATH)
+        return False
+
+    ingested_at = datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+    max_results = _env_int("RESOLVER_MAX_RESULTS")
+
+    aggregated: Dict[Tuple[str, str, str], Dict[str, Any]] = {}
+    for entry in allocations:
+        key = (entry["iso3"], entry["hazard"].code, entry["month"])
+        bucket = aggregated.setdefault(
+            key,
+            {
+                "iso3": entry["iso3"],
+                "hazard": entry["hazard"],
+                "month": entry["month"],
+                "value": 0,
+                "publishers": set(),
+                "source_types": set(),
+                "source_urls": set(),
+                "doc_titles": set(),
+                "dis_refs": [],
+            },
+        )
+        bucket["value"] += int(entry["value"])
+        bucket["publishers"].add(entry["publisher"])
+        bucket["source_types"].add(entry["source_type"])
+        if entry["source_url"]:
+            bucket["source_urls"].add(entry["source_url"])
+        if entry["doc_title"]:
+            bucket["doc_titles"].add(entry["doc_title"])
+        if entry["dis_ref"]:
+            bucket["dis_refs"].append(entry["dis_ref"])
+
+    rows: List[List[Any]] = []
+    for (iso3, hazard_code, month), bucket in sorted(aggregated.items()):
+        hazard = bucket["hazard"]
+        country_name = iso3_to_name.get(iso3, "")
+        if not country_name:
+            continue
+        value = int(round(bucket["value"]))
+        if value <= 0:
+            continue
+
+        dis_refs = bucket["dis_refs"] or [f"{iso3}-{month}"]
+        source_url = " | ".join(sorted(bucket["source_urls"]))
+        doc_title = " | ".join(sorted(bucket["doc_titles"])) or "EM-DAT events"
+        publisher = " | ".join(sorted(bucket["publishers"]))
+        source_type = " | ".join(sorted(bucket["source_types"]))
+        event_id = _build_event_id(iso3, hazard.code, month, value, source_url, dis_refs)
+
+        publication_date = f"{month}-01"
+
+        rows.append(
+            [
+                event_id,
+                country_name,
+                iso3,
+                hazard.code,
+                hazard.label,
+                hazard.hazard_class,
+                "affected",
+                SERIES_SEMANTICS,
+                str(int(value)),
+                "persons",
+                month,
+                publication_date,
+                publisher,
+                source_type,
+                source_url,
+                doc_title,
+                definition_text,
+                method,
+                "low",
+                "0",
+                ingested_at,
+            ]
+        )
+
+    if not rows:
+        dbg("no valid rows after aggregation")
+        _write_header_only(OUT_PATH)
+        return False
+
+    if max_results is not None and max_results >= 0:
+        rows = rows[: max_results]
+
+    _write_rows(rows, OUT_PATH)
+    dbg(f"wrote {len(rows)} EM-DAT rows")
+    return True
+
+
+if __name__ == "__main__":
+    main()

--- a/resolver/ingestion/run_all_stubs.py
+++ b/resolver/ingestion/run_all_stubs.py
@@ -19,8 +19,9 @@ REAL = [
     "reliefweb_client.py",
     "unhcr_client.py",
     "unhcr_odp_client.py",
-    "hdx_client.py",
     "dtm_client.py",
+    "emdat_client.py",
+    "hdx_client.py",
     "who_phe_client.py",
     "ipc_client.py",
 ]
@@ -56,6 +57,7 @@ SKIP_ENVS = {
     "unhcr_client.py": ("RESOLVER_SKIP_UNHCR", "UNHCR connector"),
     "unhcr_odp_client.py": ("RESOLVER_SKIP_UNHCR_ODP", "UNHCR ODP connector"),
     "dtm_client.py": ("RESOLVER_SKIP_DTM", "DTM connector"),
+    "emdat_client.py": ("RESOLVER_SKIP_EMDAT", "EM-DAT connector"),
     "who_phe_client.py": ("RESOLVER_SKIP_WHO", "WHO PHE connector"),
     "ipc_client.py": ("RESOLVER_SKIP_IPC", "IPC connector"),
     "hdx_client.py": ("RESOLVER_SKIP_HDX", "HDX connector"),

--- a/resolver/tests/test_connectors_headers.py
+++ b/resolver/tests/test_connectors_headers.py
@@ -72,6 +72,19 @@ def test_dtm_header_written(tmp_path, monkeypatch):
     assert row == dtm_client.CANONICAL_HEADERS
 
 
+def test_emdat_header_written(tmp_path, monkeypatch):
+    monkeypatch.setenv("RESOLVER_SKIP_EMDAT", "1")
+    from resolver.ingestion import emdat_client
+
+    emdat_client.OUT_DIR = Path(tmp_path)
+    emdat_client.OUT_PATH = Path(tmp_path) / "emdat.csv"
+    assert emdat_client.main() is False
+
+    with open(emdat_client.OUT_PATH, newline="", encoding="utf-8") as f:
+        row = next(csv.reader(f))
+    assert row == emdat_client.CANONICAL_HEADERS
+
+
 def test_ipc_header_written(tmp_path, monkeypatch):
     monkeypatch.setenv("RESOLVER_SKIP_IPC", "1")
     mod = importlib.import_module("resolver.ingestion.ipc_client")

--- a/resolver/tests/test_emdat_allocation.py
+++ b/resolver/tests/test_emdat_allocation.py
@@ -1,0 +1,100 @@
+from pathlib import Path
+
+import pandas as pd
+
+from resolver.ingestion import emdat_client
+
+
+def _make_config(csv_path: Path) -> dict:
+    return {
+        "sources": [
+            {
+                "name": "test_emdat",
+                "kind": "csv",
+                "url": str(csv_path),
+                "country_keys": ["ISO"],
+                "start_date_keys": ["Start Date"],
+                "end_date_keys": ["End Date"],
+                "type_keys": ["Disaster Type"],
+                "subtype_keys": ["Disaster Subtype"],
+                "total_affected_keys": ["Total Affected"],
+                "affected_keys": ["Affected"],
+                "injured_keys": ["Injured"],
+                "homeless_keys": ["Homeless"],
+                "id_keys": ["Dis No"],
+                "title_keys": ["Event Name"],
+                "publisher": "CRED/EM-DAT",
+                "source_type": "other",
+            }
+        ],
+        "prefer_hxl": True,
+        "allocation_policy": "prorata",
+        "shock_map": {"flood": ["Flood"]},
+        "default_hazard": "other",
+    }
+
+
+def test_emdat_allocation_prorata_vs_start(tmp_path, monkeypatch):
+    csv_path = Path(tmp_path) / "emdat_events.csv"
+    columns = [
+        "ISO",
+        "Start Date",
+        "End Date",
+        "Total Affected",
+        "Affected",
+        "Injured",
+        "Homeless",
+        "Dis No",
+        "Event Name",
+        "Disaster Type",
+        "Disaster Subtype",
+    ]
+    df = pd.DataFrame(
+        [
+            {
+                "ISO": "SDN",
+                "Start Date": "2025-01-15",
+                "End Date": "2025-03-10",
+                "Total Affected": "9000",
+                "Affected": "",
+                "Injured": "",
+                "Homeless": "",
+                "Dis No": "2025-0001",
+                "Event Name": "Flood Event",
+                "Disaster Type": "Flood",
+                "Disaster Subtype": "Riverine Flood",
+            }
+        ],
+        columns=columns,
+    )
+    df.to_csv(csv_path, index=False)
+    hxl_row = (
+        "#country+code,#date+start,#date+end,#affected+total,#affected,#affected+injured," \
+        "#affected+homeless,#event+id,#event+name,#disaster+type,#disaster+subtype"
+    )
+    lines = csv_path.read_text(encoding="utf-8").splitlines()
+    lines.insert(1, hxl_row)
+    csv_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    out_path = Path(tmp_path) / "emdat_out.csv"
+
+    monkeypatch.setenv("RESOLVER_SKIP_EMDAT", "0")
+    monkeypatch.delenv("EMDAT_ALLOC_POLICY", raising=False)
+    monkeypatch.setattr(emdat_client, "OUT_DIR", Path(tmp_path))
+    monkeypatch.setattr(emdat_client, "OUT_PATH", out_path)
+    monkeypatch.setattr(emdat_client, "load_config", lambda: _make_config(csv_path))
+
+    assert emdat_client.main() is True
+    out_df = pd.read_csv(out_path)
+    assert set(out_df["as_of_date"]) == {"2025-01", "2025-02", "2025-03"}
+    allocations = {row.as_of_date: int(row.value) for row in out_df.itertuples(index=False)}
+    assert allocations == {"2025-01": 2782, "2025-02": 4582, "2025-03": 1636}
+    assert sum(allocations.values()) == 9000
+
+    out_start = Path(tmp_path) / "emdat_start.csv"
+    monkeypatch.setenv("EMDAT_ALLOC_POLICY", "start")
+    monkeypatch.setattr(emdat_client, "OUT_PATH", out_start)
+    assert emdat_client.main() is True
+    start_df = pd.read_csv(out_start)
+    assert list(start_df["as_of_date"]) == ["2025-01"]
+    assert int(start_df.iloc[0]["value"]) == 9000

--- a/resolver/tests/test_emdat_dedup_delta.py
+++ b/resolver/tests/test_emdat_dedup_delta.py
@@ -1,0 +1,96 @@
+from pathlib import Path
+
+import pandas as pd
+
+from resolver.ingestion import emdat_client
+
+
+def _config(csv_path: Path) -> dict:
+    return {
+        "sources": [
+            {
+                "name": "emdat_dedup",
+                "kind": "csv",
+                "url": str(csv_path),
+                "country_keys": ["ISO"],
+                "start_date_keys": ["Start Date"],
+                "end_date_keys": ["End Date"],
+                "type_keys": ["Disaster Type"],
+                "subtype_keys": ["Disaster Subtype"],
+                "total_affected_keys": ["Total Affected"],
+                "affected_keys": ["Affected"],
+                "injured_keys": ["Injured"],
+                "homeless_keys": ["Homeless"],
+                "id_keys": ["Dis No"],
+                "title_keys": ["Event Name"],
+                "publisher": "CRED/EM-DAT",
+                "source_type": "other",
+            }
+        ],
+        "prefer_hxl": False,
+        "allocation_policy": "prorata",
+        "shock_map": {"flood": ["Flood"]},
+        "default_hazard": "flood",
+    }
+
+
+def test_emdat_dedup_and_monthly_aggregation(tmp_path, monkeypatch):
+    csv_path = Path(tmp_path) / "dedup.csv"
+    df = pd.DataFrame(
+        [
+            {
+                "ISO": "KEN",
+                "Start Date": "2024-02-01",
+                "End Date": "2024-02-05",
+                "Total Affected": "100",
+                "Affected": "",
+                "Injured": "",
+                "Homeless": "",
+                "Dis No": "2024-0001",
+                "Event Name": "Flood A",
+                "Disaster Type": "Flood",
+                "Disaster Subtype": "",
+            },
+            {
+                "ISO": "KEN",
+                "Start Date": "2024-02-10",
+                "End Date": "2024-02-12",
+                "Total Affected": "",
+                "Affected": "50",
+                "Injured": "",
+                "Homeless": "",
+                "Dis No": "2024-0002",
+                "Event Name": "Flood B",
+                "Disaster Type": "Flood",
+                "Disaster Subtype": "",
+            },
+            {
+                "ISO": "KEN",
+                "Start Date": "2024-02-10",
+                "End Date": "2024-02-12",
+                "Total Affected": "",
+                "Affected": "50",
+                "Injured": "",
+                "Homeless": "",
+                "Dis No": "2024-0002",
+                "Event Name": "Flood B",
+                "Disaster Type": "Flood",
+                "Disaster Subtype": "",
+            },
+        ]
+    )
+    df.to_csv(csv_path, index=False)
+
+    out_path = Path(tmp_path) / "dedup_out.csv"
+    monkeypatch.setenv("RESOLVER_SKIP_EMDAT", "0")
+    monkeypatch.delenv("EMDAT_ALLOC_POLICY", raising=False)
+    monkeypatch.setattr(emdat_client, "OUT_DIR", Path(tmp_path))
+    monkeypatch.setattr(emdat_client, "OUT_PATH", out_path)
+    monkeypatch.setattr(emdat_client, "load_config", lambda: _config(csv_path))
+
+    assert emdat_client.main() is True
+    out_df = pd.read_csv(out_path)
+    kenya = out_df[out_df["iso3"] == "KEN"].reset_index(drop=True)
+    assert len(kenya) == 1
+    assert kenya.iloc[0]["as_of_date"] == "2024-02"
+    assert int(kenya.iloc[0]["value"]) == 150

--- a/resolver/tests/test_emdat_shock_mapping.py
+++ b/resolver/tests/test_emdat_shock_mapping.py
@@ -1,0 +1,100 @@
+from pathlib import Path
+
+import pandas as pd
+
+from resolver.ingestion import emdat_client
+
+
+def _config(csv_path: Path) -> dict:
+    return {
+        "sources": [
+            {
+                "name": "emdat_mapping",
+                "kind": "csv",
+                "url": str(csv_path),
+                "country_keys": ["ISO"],
+                "start_date_keys": ["Start Date"],
+                "end_date_keys": ["End Date"],
+                "type_keys": ["Disaster Type"],
+                "subtype_keys": ["Disaster Subtype"],
+                "total_affected_keys": ["Total Affected"],
+                "affected_keys": ["Affected"],
+                "injured_keys": ["Injured"],
+                "homeless_keys": ["Homeless"],
+                "id_keys": ["Dis No"],
+                "title_keys": ["Event Name"],
+                "publisher": "CRED/EM-DAT",
+                "source_type": "other",
+            }
+        ],
+        "prefer_hxl": False,
+        "allocation_policy": "prorata",
+        "shock_map": {
+            "tropical_cyclone": ["Storm", "Tropical cyclone"],
+            "phe": ["Epidemic"],
+            "other": ["Industrial"],
+        },
+        "default_hazard": "other",
+    }
+
+
+def test_emdat_shock_mapping(tmp_path, monkeypatch):
+    csv_path = Path(tmp_path) / "mapping.csv"
+    df = pd.DataFrame(
+        [
+            {
+                "ISO": "PHL",
+                "Start Date": "2025-01-05",
+                "End Date": "2025-01-06",
+                "Total Affected": "100",
+                "Affected": "",
+                "Injured": "",
+                "Homeless": "",
+                "Dis No": "2025-1001",
+                "Event Name": "Storm Event",
+                "Disaster Type": "Storm",
+                "Disaster Subtype": "Tropical cyclone",
+            },
+            {
+                "ISO": "GIN",
+                "Start Date": "2025-02-01",
+                "End Date": "2025-02-01",
+                "Total Affected": "200",
+                "Affected": "",
+                "Injured": "",
+                "Homeless": "",
+                "Dis No": "2025-2002",
+                "Event Name": "Epidemic Event",
+                "Disaster Type": "Epidemic",
+                "Disaster Subtype": "",
+            },
+            {
+                "ISO": "USA",
+                "Start Date": "2025-03-10",
+                "End Date": "2025-03-12",
+                "Total Affected": "300",
+                "Affected": "",
+                "Injured": "",
+                "Homeless": "",
+                "Dis No": "2025-3003",
+                "Event Name": "Mystery Event",
+                "Disaster Type": "Mystery",
+                "Disaster Subtype": "",
+            },
+        ]
+    )
+    df.to_csv(csv_path, index=False)
+
+    out_path = Path(tmp_path) / "mapping_out.csv"
+    monkeypatch.setenv("RESOLVER_SKIP_EMDAT", "0")
+    monkeypatch.delenv("EMDAT_ALLOC_POLICY", raising=False)
+    monkeypatch.setattr(emdat_client, "OUT_DIR", Path(tmp_path))
+    monkeypatch.setattr(emdat_client, "OUT_PATH", out_path)
+    monkeypatch.setattr(emdat_client, "load_config", lambda: _config(csv_path))
+
+    assert emdat_client.main() is True
+    out_df = pd.read_csv(out_path)
+    mapping = {row.iso3: row.hazard_code for row in out_df.itertuples(index=False)}
+    assert mapping["PHL"] == "TC"
+    assert mapping["GIN"] == "PHE"
+    assert mapping["USA"] == "OT"

--- a/resolver/tools/precedence_config.yml
+++ b/resolver/tools/precedence_config.yml
@@ -1,8 +1,8 @@
 # Policy knobs (kept here so we don't hardcode in code)
 metric_preference: [in_need, affected]   # PIN first, else PA
 tiers:
-  - ["unhcr_api", "unhcr_odp", "ifrc_go", "who", "ipc"]
-  - ["dtm", "hdx"]
+  - ["unhcr_api", "unhcr_odp", "ifrc_go", "who", "ipc", "dtm"]
+  - ["hdx", "emdat"]
   - ["reliefweb", "media"]
 source_precedence:                       # highest → lowest (legacy policy tiers)
   - inter_agency_plan
@@ -30,8 +30,8 @@ source_mapping:
     source_type: ["official"]
     publisher: ["WHO"]
   reputable_ingo_un:
-    source_type: ["agency"]
-    publisher: ["EM-DAT", "GDACS", "Copernicus EMS", "UNOSAT", "FEWS NET", "WFP mVAM"]
+    source_type: ["agency", "other"]
+    publisher: ["EM-DAT", "CRED/EM-DAT", "GDACS", "Copernicus EMS", "UNOSAT", "FEWS NET", "WFP mVAM"]
   dtm:
     source_type: ["cluster", "agency"]
     publisher: ["IOM-DTM"]
@@ -60,3 +60,4 @@ lags:
   who: 2d
   dtm: 2d
   hdx: 3d
+  emdat: 7d


### PR DESCRIPTION
## Summary
- add an EM-DAT ingestion client that expands event totals into monthly incident PA rows with hazard mapping and deterministic IDs
- provide EM-DAT source configuration, extend the hazard registry, hook the connector into the runner/precedence flow, and document the allocation policy
- cover the new connector with header, allocation, shock mapping, and deduplication tests

## Testing
- pytest resolver/tests/test_emdat_allocation.py resolver/tests/test_emdat_shock_mapping.py resolver/tests/test_emdat_dedup_delta.py resolver/tests/test_connectors_headers.py

------
https://chatgpt.com/codex/tasks/task_e_68de7fae6b48832ca705c79e0370b08d