### PR TITLE
fix: guard UNHCR pagination and add ingestion mode

### DIFF
--- a/.github/workflows/resolver-ci.yml
+++ b/.github/workflows/resolver-ci.yml
@@ -43,7 +43,7 @@ jobs:
           RESOLVER_DEBUG: "1"
           RESOLVER_MAX_PAGES: "5"
           RESOLVER_MAX_RESULTS: "1000"
-          RESOLVER_INCLUDE_STUBS: "0"
+          RESOLVER_INGESTION_MODE: real
           RESOLVER_FAIL_ON_STUB_ERROR: "0"
         run: |
           python resolver/ingestion/run_all_stubs.py
@@ -52,7 +52,7 @@ jobs:
         if: ${{ always() }}
         env:
           PYTHONPATH: ${{ github.workspace }}
-          RESOLVER_INCLUDE_STUBS: "1"
+          RESOLVER_INGESTION_MODE: stubs
           RESOLVER_FAIL_ON_STUB_ERROR: "0"
         run: |
           python resolver/ingestion/run_all_stubs.py || true
@@ -128,7 +128,7 @@ jobs:
           RESOLVER_DEBUG: "1"
           RESOLVER_MAX_PAGES: "5"
           RESOLVER_MAX_RESULTS: "1000"
-          RESOLVER_INCLUDE_STUBS: "0"
+          RESOLVER_INGESTION_MODE: real
           RESOLVER_FAIL_ON_STUB_ERROR: "0"
         run: |
           python resolver/ingestion/run_all_stubs.py
@@ -137,7 +137,7 @@ jobs:
         if: ${{ always() }}
         env:
           PYTHONPATH: ${{ github.workspace }}
-          RESOLVER_INCLUDE_STUBS: "1"
+          RESOLVER_INGESTION_MODE: stubs
           RESOLVER_FAIL_ON_STUB_ERROR: "0"
         run: |
           python resolver/ingestion/run_all_stubs.py || true

--- a/resolver/ingestion/unhcr_client.py
+++ b/resolver/ingestion/unhcr_client.py
@@ -144,11 +144,15 @@ def make_rows() -> List[List[str]]:
         while page <= MAX_PAGES:
             params = dict(base_params)
             params["page"] = str(page)
+
+            results: List[Dict[str, Any]] = []
+            r = None
             try:
                 r = requests.get(url, params=params, headers=headers, timeout=30)
             except requests.RequestException as exc:
                 dbg(f"request for {yr} page {page} raised {exc}")
                 break
+
             request_idx += 1
             if _debug() and (request_idx % DEBUG_EVERY == 1):
                 dbg(f"GET {r.url} -> {r.status_code}")
@@ -157,11 +161,13 @@ def make_rows() -> List[List[str]]:
 
             try:
                 data = r.json()
-            except ValueError:
-                dbg("response JSON decode failed; skipping year %s page %s" % (yr, page))
+            except ValueError as exc:
+                dbg(
+                    "response JSON decode failed; skipping year %s page %s (%s)"
+                    % (yr, page, exc)
+                )
                 break
 
-            results: List[Dict[str, Any]] = []
             if isinstance(data, list):
                 results = [item for item in data if isinstance(item, dict)]
             elif isinstance(data, dict):

--- a/resolver/tests/test_runner_modes.py
+++ b/resolver/tests/test_runner_modes.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+
+def _prepare_module(monkeypatch, tmp_path: Path, mode: str):
+    monkeypatch.setenv("RESOLVER_INGESTION_MODE", mode)
+    monkeypatch.delenv("RESOLVER_INCLUDE_STUBS", raising=False)
+    monkeypatch.delenv("RESOLVER_FORCE_DTM_STUB", raising=False)
+    monkeypatch.delenv("RESOLVER_FAIL_ON_STUB_ERROR", raising=False)
+
+    import resolver.ingestion.run_all_stubs as run_all_stubs
+
+    module = importlib.reload(run_all_stubs)
+
+    monkeypatch.setattr(module, "ROOT", tmp_path)
+
+    for name in set(module.REAL + module.STUBS):
+        (tmp_path / name).write_text("", encoding="utf-8")
+
+    return module
+
+
+def test_runner_stubs_mode_runs_only_stubs(monkeypatch, tmp_path):
+    module = _prepare_module(monkeypatch, tmp_path, "stubs")
+
+    calls: list[str] = []
+
+    monkeypatch.setattr(module, "_run_script", lambda path: calls.append(path.name) or 0)
+
+    module.main()
+
+    assert calls, "expected stub scripts to run"
+    assert set(calls) == set(module.STUBS)
+
+    monkeypatch.delenv("RESOLVER_INGESTION_MODE", raising=False)
+    importlib.reload(module)
+
+
+def test_runner_real_mode_skips_stubs(monkeypatch, tmp_path):
+    module = _prepare_module(monkeypatch, tmp_path, "real")
+
+    calls: list[str] = []
+
+    monkeypatch.setattr(module, "_run_script", lambda path: calls.append(path.name) or 0)
+
+    module.main()
+
+    assert calls, "expected real connectors to run"
+    assert set(calls) == set(module.REAL)
+
+    monkeypatch.delenv("RESOLVER_INGESTION_MODE", raising=False)
+    importlib.reload(module)

--- a/resolver/tests/test_unhcr_paging_guards.py
+++ b/resolver/tests/test_unhcr_paging_guards.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import importlib
+
+import pandas as pd
+
+
+def test_unhcr_make_rows_handles_json_error(monkeypatch):
+    monkeypatch.delenv("RESOLVER_SKIP_UNHCR", raising=False)
+
+    import resolver.ingestion.unhcr_client as unhcr_client
+
+    unhcr_client = importlib.reload(unhcr_client)
+
+    monkeypatch.setattr(
+        unhcr_client,
+        "load_cfg",
+        lambda: {
+            "base_url": "https://example.com",
+            "endpoints": {"asylum_applications": "/apps"},
+            "user_agent": "pytest",
+            "window_days": 30,
+            "params": {
+                "cf_type": "ISO",
+                "coo_all": "true",
+                "coa_all": "true",
+            },
+            "defaults": {"max_results": 10, "debug_every": 1, "max_pages": 2},
+            "page_size": 5,
+        },
+    )
+
+    def _fake_registries():
+        countries = pd.DataFrame(
+            [
+                {
+                    "country_name": "Exampleland",
+                    "iso3": "EXA",
+                    "country_norm": "exampleland",
+                }
+            ]
+        )
+        shocks = pd.DataFrame(
+            [
+                {
+                    "hazard_code": "DI",
+                    "hazard_label": "Displacement influx",
+                    "hazard_class": "conflict",
+                }
+            ]
+        )
+        return countries, shocks
+
+    monkeypatch.setattr(unhcr_client, "load_registries", _fake_registries)
+
+    class _Response:
+        status_code = 200
+        url = "https://example.com/apps?page=1"
+
+        def json(self):
+            raise ValueError("bad json")
+
+    monkeypatch.setattr(unhcr_client.requests, "get", lambda *_, **__: _Response())
+
+    rows = unhcr_client.make_rows()
+
+    assert rows == []


### PR DESCRIPTION
## Summary
- guard the UNHCR pagination loop against request and JSON errors so results are always initialized before length checks
- add a RESOLVER_INGESTION_MODE flag to run_all_stubs.py and update the CI workflow to run real, stubs, or both connectors explicitly
- add unit tests covering the UNHCR guard behavior and the new runner modes

## Testing
- pytest resolver/tests/test_unhcr_paging_guards.py resolver/tests/test_runner_modes.py


------
https://chatgpt.com/codex/tasks/task_e_68de836e96f4832c8772ee2f19629570