### PR TITLE
Remove earthquake hazard from shocks registry

### DIFF
--- a/resolver/data/shocks.csv
+++ b/resolver/data/shocks.csv
@@ -7,7 +7,6 @@ CW,Cold Wave,natural
 WF,Wildfire,natural
 LS,Landslide,natural
 VO,Volcanic Activity,natural
-EQ,Earthquake,natural
 ACO,Armed Conflict - Onset,human-induced
 ACE,Armed Conflict - Escalation,human-induced
 ACC,Armed Conflict - Cessation,human-induced

--- a/resolver/ingestion/config/emdat.yml
+++ b/resolver/ingestion/config/emdat.yml
@@ -24,7 +24,6 @@ shock_map:
   heat_wave: ["Heat wave", "Extreme temperature", "Heat"]
   cold_wave: ["Cold wave", "Extreme cold", "Cold"]
   wildfire: ["Wildfire", "Forest fire", "Fire"]
-  earthquake: ["Earthquake", "Seismic"]
   landslide: ["Landslide"]
   volcano: ["Volcanic activity", "Volcano"]
   phe: ["Epidemic", "Infectious disease", "Outbreak"]

--- a/resolver/ingestion/emdat_client.py
+++ b/resolver/ingestion/emdat_client.py
@@ -57,7 +57,6 @@ HAZARD_KEY_TO_CODE = {
     "heat_wave": "HW",
     "cold_wave": "CW",
     "wildfire": "WF",
-    "earthquake": "EQ",
     "landslide": "LS",
     "volcano": "VO",
     "phe": "PHE",


### PR DESCRIPTION
## Summary
- remove the earthquake hazard row from the shocks registry CSV
- drop the earthquake hazard mapping from the EM-DAT ingestion config and client lookup

## Testing
- pytest resolver/tests/test_registries.py *(fails: hazard_class includes other/multi values outside the allowed set)*

------
https://chatgpt.com/codex/tasks/task_e_68de89b25cfc832ca4ae51fa8a1dbae5