### PR TITLE
Add WFP mVAM connector with monthly aggregation

### DIFF
--- a/resolver/ingestion/README.md
+++ b/resolver/ingestion/README.md
@@ -212,6 +212,20 @@ UNHCR’s public API exposes `/asylum-applications/`, `/population/`, `/asylum-d
   - `HDX_BASE=<url>` — override base URL (default `https://data.humdata.org`).
   - `RELIEFWEB_APPNAME` — optional User-Agent override reused from the ReliefWeb connector.
 
+## WFP mVAM — real connector
+
+- **Config-driven:** Sources defined in `ingestion/config/wfp_mvam.yml`; supports CSV/XLSX/JSON exports with optional HXL tags.
+- **Monthly-first:** Daily/weekly series are averaged to the month before conversion. Example: two February IFC readings of
+  `10%` and `12%` with a 100,000-person population average to `11%`, yielding `round(0.11 * 100000) = 11,000` people in need.
+- **Percent → people:** Prefer direct people columns. If only prevalence is available and `WFP_MVAM_ALLOW_PERCENT=1`, the
+  connector multiplies the monthly mean (%) by a population denominator (dataset column first, then `WFP_MVAM_DENOMINATOR_FILE`).
+- **Outputs:** Emits national **stock** (`series_semantics=stock`) and optional **incident** (`incident` delta) streams with
+  deterministic IDs per ISO3/hazard/month. Negative deltas are clipped to zero.
+- **Shocks:** Keyword lexicon maps drivers/tags to drought, economic crisis, conflict, flood, or `MULTI` (Multi-driver Food
+  Insecurity) when ambiguous.
+- **Env toggles:** `RESOLVER_SKIP_WFP_MVAM=1`, `WFP_MVAM_ALLOW_PERCENT`, `WFP_MVAM_STOCK`, `WFP_MVAM_INCIDENT`,
+  `WFP_MVAM_INCLUDE_FIRST_MONTH_DELTA`, `WFP_MVAM_DENOMINATOR_FILE`, `WFP_MVAM_INDICATOR_PRIORITY`.
+
 ## Source notes (what each adds)
 
 - **EM-DAT** — standardized disaster records and “people affected”; lagged but consistent.

--- a/resolver/ingestion/config/wfp_mvam.yml
+++ b/resolver/ingestion/config/wfp_mvam.yml
@@ -1,0 +1,32 @@
+sources:
+  - name: mvam_ifc_global
+    kind: csv
+    url: https://example.org/wfp_mvam_ifc.csv
+    time_keys: ["date", "week", "month", "#date"]
+    country_keys: ["iso3", "#country+code", "country_iso3", "country"]
+    admin_keys: ["adm1", "adm2", "#adm1+name", "#adm2+name"]
+    pct_keys: ["ifc_pct", "insufficient_food_consumption_pct", "#food+consumption:insufficient+%"]
+    people_keys: ["ifc_people", "people_ifc", "#inneed"]
+    population_keys: ["pop", "population", "#population"]
+    driver_keys: ["driver", "drivers", "tags", "notes"]
+    series_hint: stock
+    publisher: "WFP"
+    source_type: "official"
+
+prefer_hxl: true
+monthly_first: true
+allow_percent: false
+denominator_file: "resolver/data/population.csv"
+indicator_priority: ["people_ifc", "ifc_pct", "rcsi"]
+
+shock_keywords:
+  economic_crisis: ["price", "inflation", "market", "currency", "terms of trade"]
+  drought: ["drought", "dry spell", "rainfall deficit"]
+  flood: ["flood", "inundation", "heavy rain"]
+  armed_conflict_escalation: ["conflict", "clashes", "violence", "insecurity"]
+  phe: ["cholera", "measles", "outbreak", "epidemic"]
+default_hazard: "multi"
+
+emit_stock: true
+emit_incident: true
+include_first_month_delta: false

--- a/resolver/ingestion/run_all_stubs.py
+++ b/resolver/ingestion/run_all_stubs.py
@@ -26,6 +26,7 @@ REAL = [
     "hdx_client.py",
     "who_phe_client.py",
     "ipc_client.py",
+    "wfp_mvam_client.py",
 ]
 
 STUBS = [
@@ -64,6 +65,7 @@ SKIP_ENVS = {
     "who_phe_client.py": ("RESOLVER_SKIP_WHO", "WHO PHE connector"),
     "ipc_client.py": ("RESOLVER_SKIP_IPC", "IPC connector"),
     "hdx_client.py": ("RESOLVER_SKIP_HDX", "HDX connector"),
+    "wfp_mvam_client.py": ("RESOLVER_SKIP_WFP_MVAM", "WFP mVAM connector"),
 }
 
 

--- a/resolver/ingestion/wfp_mvam_client.py
+++ b/resolver/ingestion/wfp_mvam_client.py
@@ -1,0 +1,791 @@
+#!/usr/bin/env python3
+"""WFP mVAM connector producing monthly national food insecurity counts."""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import io
+import math
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+import pandas as pd
+import requests
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA = ROOT / "data"
+STAGING = ROOT / "staging"
+DEFAULT_CONFIG = ROOT / "ingestion" / "config" / "wfp_mvam.yml"
+CONFIG = DEFAULT_CONFIG
+COUNTRIES = DATA / "countries.csv"
+SHOCKS = DATA / "shocks.csv"
+OUT_PATH = STAGING / "wfp_mvam.csv"
+
+CANONICAL_HEADERS = [
+    "event_id",
+    "country_name",
+    "iso3",
+    "hazard_code",
+    "hazard_label",
+    "hazard_class",
+    "metric",
+    "series_semantics",
+    "value",
+    "unit",
+    "as_of_date",
+    "publication_date",
+    "publisher",
+    "source_type",
+    "source_url",
+    "doc_title",
+    "definition_text",
+    "method",
+    "confidence",
+    "revision",
+    "ingested_at",
+]
+
+DEFAULT_PUBLISHER = "WFP"
+DEFAULT_SOURCE_TYPE = "official"
+DEFAULT_UNIT = "persons"
+DEFAULT_METRIC = "in_need"
+DEFAULT_MULTI = ("MULTI", "Multi-driver Food Insecurity", "multi")
+DEBUG = os.getenv("RESOLVER_DEBUG", "0") == "1"
+
+HAZARD_KEY_TO_CODE = {
+    "economic_crisis": "EC",
+    "drought": "DR",
+    "flood": "FL",
+    "armed_conflict_escalation": "ACE",
+    "phe": "PHE",
+}
+
+@dataclass
+class Hazard:
+    code: str
+    label: str
+    hazard_class: str
+
+
+def dbg(message: str) -> None:
+    if DEBUG:
+        print(f"[wfp_mvam] {message}")
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _ingested_timestamp() -> str:
+    return dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _digest(parts: Sequence[Any]) -> str:
+    joined = "|".join(str(p) for p in parts)
+    return hashlib.sha1(joined.encode("utf-8")).hexdigest()[:12]
+
+
+def _parse_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        if math.isnan(value):
+            return None
+        return float(value)
+    text = str(value).strip()
+    if not text:
+        return None
+    text = text.replace(",", "")
+    try:
+        parsed = float(text)
+    except Exception:
+        return None
+    if math.isnan(parsed):
+        return None
+    return float(parsed)
+
+
+def _parse_date(value: Any) -> Optional[pd.Timestamp]:
+    if value is None:
+        return None
+    if isinstance(value, pd.Timestamp):
+        if pd.isna(value):
+            return None
+        return value
+    text = str(value).strip()
+    if not text:
+        return None
+    parsed = pd.to_datetime(text, errors="coerce")
+    if pd.isna(parsed):
+        return None
+    return parsed
+
+
+def _month_key(value: pd.Timestamp) -> Optional[str]:
+    if value is None:
+        return None
+    return f"{value.year:04d}-{value.month:02d}"
+
+
+def load_config() -> Dict[str, Any]:
+    with open(CONFIG, "r", encoding="utf-8") as fp:
+        return yaml.safe_load(fp) or {}
+
+
+def load_countries() -> pd.DataFrame:
+    df = pd.read_csv(COUNTRIES, dtype=str).fillna("")
+    return df
+
+
+def load_shocks() -> pd.DataFrame:
+    df = pd.read_csv(SHOCKS, dtype=str).fillna("")
+    return df
+
+
+def _write_header_only(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(columns=CANONICAL_HEADERS).to_csv(path, index=False)
+
+
+def _write_rows(rows: List[List[Any]], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df = pd.DataFrame(rows, columns=CANONICAL_HEADERS)
+    df.to_csv(path, index=False)
+
+
+def _maybe_apply_hxl(df: pd.DataFrame) -> pd.DataFrame:
+    if df.empty:
+        return df
+    first_row = df.iloc[0]
+    if all(isinstance(v, str) and v.startswith("#") for v in first_row):
+        df = df.iloc[1:].reset_index(drop=True)
+        df.columns = [str(v).strip() for v in first_row]
+        return df
+    if any(col.startswith("#") for col in df.columns):
+        df.columns = [str(c).strip() for c in df.columns]
+        return df
+    if all(isinstance(v, str) and v.startswith("#") for v in df.columns):
+        df.columns = [str(c).strip() for c in df.columns]
+    return df
+
+
+def _normalise_columns(df: pd.DataFrame) -> Dict[str, str]:
+    mapping: Dict[str, str] = {}
+    for col in df.columns:
+        lower = str(col).strip().lower()
+        mapping[lower] = col
+    return mapping
+
+
+def _find_column(mapping: Dict[str, str], keys: Iterable[str]) -> Optional[str]:
+    for key in keys:
+        if not key:
+            continue
+        key_lower = key.strip().lower()
+        if key_lower in mapping:
+            return mapping[key_lower]
+    return None
+
+
+def _extract_text(row: pd.Series, columns: List[str]) -> str:
+    parts: List[str] = []
+    for col in columns:
+        if col not in row:
+            continue
+        value = row[col]
+        if pd.isna(value):
+            continue
+        text = str(value).strip()
+        if text:
+            parts.append(text)
+    return " ".join(parts)
+
+
+def _load_dataframe(source: Dict[str, Any]) -> Optional[pd.DataFrame]:
+    url = source.get("url")
+    if not url:
+        return None
+    kind = (source.get("kind") or "csv").lower()
+    appname = os.getenv("RELIEFWEB_APPNAME")
+    if url.startswith("http://") or url.startswith("https://"):
+        headers = {"User-Agent": appname} if appname else None
+        resp = requests.get(url, headers=headers, timeout=60)
+        if resp.status_code != 200:
+            dbg(f"download failed for {url}: {resp.status_code}")
+            return None
+        data = io.BytesIO(resp.content)
+        if kind == "csv":
+            return pd.read_csv(data)
+        if kind in {"xlsx", "xls", "excel"}:
+            return pd.read_excel(data)
+        if kind == "json":
+            return pd.read_json(io.BytesIO(resp.content))
+        return pd.read_csv(data)
+    path = Path(url)
+    if not path.exists():
+        dbg(f"source path {url} missing")
+        return None
+    if kind == "csv":
+        return pd.read_csv(path)
+    if kind in {"xlsx", "xls", "excel"}:
+        return pd.read_excel(path)
+    if kind == "json":
+        return pd.read_json(path)
+    return pd.read_csv(path)
+
+
+def _load_denominator_table(path: Optional[str]) -> Optional[pd.DataFrame]:
+    if not path:
+        return None
+    denom_path = Path(path)
+    if not denom_path.exists():
+        dbg(f"denominator file {path} missing")
+        return None
+    df = pd.read_csv(denom_path, dtype=str)
+    df = df.rename(columns={c: c.strip().lower() for c in df.columns})
+    for col in ["population", "pop", "value"]:
+        if col in df.columns:
+            df[col] = df[col].apply(_parse_float)
+    if "year" in df.columns:
+        df["year"] = df["year"].apply(lambda x: int(float(x)) if _parse_float(x) is not None else None)
+    return df
+
+
+def _lookup_denominator(df: Optional[pd.DataFrame], iso3: str, year: int) -> Optional[float]:
+    if df is None or df.empty:
+        return None
+    data = df.copy()
+    if "iso3" not in data.columns:
+        return None
+    sample = data[data["iso3"].str.upper() == iso3.upper()]
+    if sample.empty:
+        return None
+    if "population" in sample.columns:
+        pop_col = "population"
+    elif "pop" in sample.columns:
+        pop_col = "pop"
+    else:
+        pop_col = None
+    if pop_col is None:
+        return None
+    if "year" in sample.columns and sample["year"].notna().any():
+        exact = sample[sample["year"] == year]
+        if exact.empty:
+            exact = sample[sample["year"] < year]
+        if exact.empty:
+            exact = sample
+        sample = exact
+    population = sample[pop_col].dropna()
+    if population.empty:
+        return None
+    return float(population.iloc[-1])
+
+
+def _resolve_hazard(code: str, shocks: pd.DataFrame) -> Hazard:
+    match = shocks[shocks["hazard_code"].str.upper() == code.upper()]
+    if match.empty:
+        return Hazard(*DEFAULT_MULTI)
+    row = match.iloc[0]
+    return Hazard(row["hazard_code"], row["hazard_label"], row["hazard_class"])
+
+
+def _infer_hazard(texts: Iterable[str], shocks: pd.DataFrame, cfg: Dict[str, Any]) -> Hazard:
+    keywords = cfg.get("shock_keywords", {})
+    default_code = str(cfg.get("default_hazard", "multi"))
+    sample = " ".join(str(t).lower() for t in texts if t)
+    matches: List[str] = []
+    for key, words in keywords.items():
+        for word in words:
+            if word.lower() in sample:
+                matches.append(key)
+                break
+    unique = sorted(set(matches))
+    if not unique:
+        if default_code.lower() == "multi":
+            return Hazard(*DEFAULT_MULTI)
+        return _resolve_hazard(default_code, shocks)
+    if len(unique) > 1:
+        return Hazard(*DEFAULT_MULTI)
+    hazard_key = unique[0]
+    code = HAZARD_KEY_TO_CODE.get(hazard_key)
+    if not code:
+        return Hazard(*DEFAULT_MULTI)
+    return _resolve_hazard(code, shocks)
+
+
+def _aggregate_people(group: pd.DataFrame) -> Optional[float]:
+    values = group["value"].apply(_parse_float).dropna()
+    if values.empty:
+        return None
+    hint = group["series_hint"].dropna().iloc[0] if not group["series_hint"].dropna().empty else "stock"
+    if hint == "incident":
+        return float(values.sum())
+    return float(values.mean())
+
+
+def _aggregate_percent(group: pd.DataFrame) -> Optional[float]:
+    values = group["value"].apply(_parse_float).dropna()
+    if values.empty:
+        return None
+    return float(values.mean())
+
+
+def collect_rows() -> List[List[Any]]:
+    cfg = load_config()
+    countries = load_countries()
+    shocks = load_shocks()
+
+    country_lookup = {row.iso3.upper(): row.country_name for row in countries.itertuples()}
+
+    allow_percent = _env_bool("WFP_MVAM_ALLOW_PERCENT", bool(cfg.get("allow_percent", False)))
+    emit_stock = _env_bool("WFP_MVAM_STOCK", bool(cfg.get("emit_stock", True)))
+    emit_incident = _env_bool("WFP_MVAM_INCIDENT", bool(cfg.get("emit_incident", True)))
+    include_first_month = _env_bool(
+        "WFP_MVAM_INCLUDE_FIRST_MONTH_DELTA",
+        bool(cfg.get("include_first_month_delta", False)),
+    )
+
+    priority_env = os.getenv("WFP_MVAM_INDICATOR_PRIORITY")
+    if priority_env:
+        indicator_priority = [item.strip() for item in priority_env.split(",") if item.strip()]
+    else:
+        indicator_priority = cfg.get("indicator_priority", [])
+
+    prefer_hxl = bool(cfg.get("prefer_hxl", False))
+    denominator_override = os.getenv("WFP_MVAM_DENOMINATOR_FILE")
+    denominator_path = denominator_override or cfg.get("denominator_file")
+    denominator_table = _load_denominator_table(denominator_path) if allow_percent else None
+
+    records: List[Dict[str, Any]] = []
+
+    sources = cfg.get("sources", []) or []
+    for source in sources:
+        df = _load_dataframe(source)
+        if df is None or df.empty:
+            continue
+        if prefer_hxl:
+            df = _maybe_apply_hxl(df)
+        else:
+            df.columns = [str(c).strip() for c in df.columns]
+
+        column_map = _normalise_columns(df)
+        time_col = _find_column(column_map, source.get("time_keys", []))
+        country_col = _find_column(column_map, source.get("country_keys", []))
+        admin_cols: List[str] = []
+        for key in source.get("admin_keys", []):
+            col = _find_column(column_map, [key])
+            if col and col not in admin_cols:
+                admin_cols.append(col)
+        pct_col = _find_column(column_map, source.get("pct_keys", []))
+        people_col = _find_column(column_map, source.get("people_keys", []))
+        population_col = _find_column(column_map, source.get("population_keys", []))
+        driver_cols: List[str] = []
+        for key in source.get("driver_keys", []):
+            col = _find_column(column_map, [key])
+            if col and col not in driver_cols:
+                driver_cols.append(col)
+
+        metric = source.get("metric", DEFAULT_METRIC)
+        series_hint = source.get("series_hint", "stock")
+        publisher = source.get("publisher", DEFAULT_PUBLISHER)
+        source_type = source.get("source_type", DEFAULT_SOURCE_TYPE)
+        source_url = source.get("url", "")
+        doc_title = source.get("name") or "WFP mVAM dataset"
+        source_id = source.get("name") or source_url or "wfp_mvam"
+
+        if not time_col or not country_col:
+            continue
+
+        for _, row in df.iterrows():
+            iso_raw = row.get(country_col)
+            if pd.isna(iso_raw):
+                continue
+            iso3 = str(iso_raw).strip().upper()
+            if len(iso3) != 3 or iso3 not in country_lookup:
+                continue
+
+            date_raw = row.get(time_col)
+            parsed_date = _parse_date(date_raw)
+            if parsed_date is None:
+                continue
+            month = _month_key(parsed_date)
+            if not month:
+                continue
+
+            indicator_col = None
+            indicator_kind = None
+            indicator_name = None
+
+            if indicator_priority:
+                for candidate in indicator_priority:
+                    lower = candidate.lower()
+                    if "people" in lower and people_col:
+                        indicator_col = people_col
+                        indicator_kind = "people"
+                        indicator_name = candidate
+                        break
+                    if "pct" in lower or "%" in lower:
+                        if pct_col:
+                            indicator_col = pct_col
+                            indicator_kind = "percent"
+                            indicator_name = candidate
+                            break
+                    if "rcsi" in lower:
+                        rcsi_col = column_map.get("rcsi")
+                        if rcsi_col:
+                            indicator_col = rcsi_col
+                            indicator_kind = "rcsi"
+                            indicator_name = candidate
+                            break
+            if not indicator_col:
+                if people_col is not None:
+                    indicator_col = people_col
+                    indicator_kind = "people"
+                    indicator_name = people_col
+                elif pct_col is not None:
+                    indicator_col = pct_col
+                    indicator_kind = "percent"
+                    indicator_name = pct_col
+                else:
+                    continue
+
+            raw_value = row.get(indicator_col)
+            parsed_value = _parse_float(raw_value)
+            if parsed_value is None:
+                continue
+
+            population_value = None
+            if population_col:
+                population_value = _parse_float(row.get(population_col))
+
+            admin_parts: List[str] = []
+            for col in admin_cols:
+                val = row.get(col)
+                if pd.isna(val):
+                    continue
+                text_val = str(val).strip()
+                if text_val:
+                    admin_parts.append(text_val)
+            admin_name = "|".join([p for p in admin_parts if p])
+
+            driver_text = _extract_text(row, driver_cols)
+            hazard = _infer_hazard([doc_title, driver_text], shocks, cfg)
+
+            record = {
+                "iso3": iso3,
+                "country_name": country_lookup.get(iso3, ""),
+                "month": month,
+                "value": parsed_value,
+                "indicator_kind": indicator_kind,
+                "indicator_name": indicator_name,
+                "series_hint": series_hint,
+                "population": population_value,
+                "metric": metric,
+                "hazard_code": hazard.code,
+                "hazard_label": hazard.label,
+                "hazard_class": hazard.hazard_class,
+                "publisher": publisher,
+                "source_type": source_type,
+                "source_url": source_url,
+                "doc_title": doc_title,
+                "driver_text": driver_text,
+                "admin_name": admin_name,
+                "source_id": source_id,
+            }
+            records.append(record)
+
+    if not records:
+        return []
+
+    df_records = pd.DataFrame(records)
+
+    admin_groups = (
+        df_records.groupby(
+            [
+                "iso3",
+                "hazard_code",
+                "hazard_label",
+                "hazard_class",
+                "metric",
+                "source_id",
+                "month",
+                "admin_name",
+            ],
+            dropna=False,
+        )
+    )
+
+    admin_aggregated: List[Dict[str, Any]] = []
+
+    for (iso3, hz_code, hz_label, hz_class, metric, source_id, month, admin_name), group in admin_groups:
+        if group["indicator_kind"].eq("people").any():
+            chosen = group[group["indicator_kind"] == "people"]
+            agg_value = _aggregate_people(chosen)
+            if agg_value is None:
+                continue
+            conversion_method = "people direct"
+            names = chosen["indicator_name"].dropna()
+            indicator_label = names.iloc[0] if not names.empty else "people"
+            definition_note = f"Direct people counts ({indicator_label})"
+        elif group["indicator_kind"].eq("percent").any() and allow_percent:
+            chosen = group[group["indicator_kind"] == "percent"]
+            pct_value = _aggregate_percent(chosen)
+            if pct_value is None:
+                continue
+            population_value = chosen["population"].dropna()
+            denominator = float(population_value.iloc[0]) if not population_value.empty else None
+            denominator_source = "dataset population"
+            if denominator is None:
+                year = int(month.split("-")[0])
+                denominator = _lookup_denominator(denominator_table, iso3, year)
+                denominator_source = "denominator file"
+            if denominator is None or denominator <= 0:
+                continue
+            agg_value = round(pct_value / 100.0 * denominator)
+            conversion_method = f"pct→people ({denominator_source})"
+            definition_note = (
+                f"Monthly mean prevalence {pct_value:.2f}% converted using {denominator_source}"
+            )
+            chosen = chosen.iloc[[0]]
+        else:
+            continue
+
+        if agg_value is None or agg_value <= 0:
+            continue
+
+        row_template = chosen.iloc[0]
+        admin_aggregated.append(
+            {
+                "iso3": iso3,
+                "country_name": row_template.get("country_name", ""),
+                "hazard_code": hz_code,
+                "hazard_label": hz_label,
+                "hazard_class": hz_class,
+                "metric": metric,
+                "source_id": source_id,
+                "month": month,
+                "admin_name": admin_name,
+                "value": float(agg_value),
+                "publisher": row_template.get("publisher", DEFAULT_PUBLISHER),
+                "source_type": row_template.get("source_type", DEFAULT_SOURCE_TYPE),
+                "source_url": row_template.get("source_url", ""),
+                "doc_title": row_template.get("doc_title", "WFP mVAM"),
+                "driver_text": row_template.get("driver_text", ""),
+                "conversion_method": conversion_method,
+                "definition_note": definition_note,
+            }
+        )
+
+    if not admin_aggregated:
+        return []
+
+    df_admin = pd.DataFrame(admin_aggregated)
+
+    national_groups = (
+        df_admin.groupby(
+            ["iso3", "hazard_code", "hazard_label", "hazard_class", "metric", "source_id", "month"],
+            dropna=False,
+        )
+    )
+
+    national_records: List[Dict[str, Any]] = []
+
+    for (iso3, hz_code, hz_label, hz_class, metric, source_id, month), group in national_groups:
+        total_value = group["value"].sum()
+        if total_value <= 0:
+            continue
+        conversion_methods = sorted(set(group["conversion_method"].dropna()))
+        definition_notes = sorted(set(group["definition_note"].dropna()))
+        doc_title = group["doc_title"].dropna().iloc[0] if not group["doc_title"].dropna().empty else "WFP mVAM"
+        source_url = group["source_url"].dropna().iloc[0] if not group["source_url"].dropna().empty else ""
+        publisher = group["publisher"].dropna().iloc[0] if not group["publisher"].dropna().empty else DEFAULT_PUBLISHER
+        source_type = group["source_type"].dropna().iloc[0] if not group["source_type"].dropna().empty else DEFAULT_SOURCE_TYPE
+        driver_texts = sorted({text for text in group["driver_text"].dropna() if text})
+
+        national_records.append(
+            {
+                "iso3": iso3,
+                "country_name": group["country_name"].dropna().iloc[0] if not group["country_name"].dropna().empty else "",
+                "hazard_code": hz_code,
+                "hazard_label": hz_label,
+                "hazard_class": hz_class,
+                "metric": metric,
+                "source_id": source_id,
+                "month": month,
+                "value": int(round(total_value)),
+                "publisher": publisher,
+                "source_type": source_type,
+                "source_url": source_url,
+                "doc_title": doc_title,
+                "driver_text": "; ".join(driver_texts),
+                "conversion_method": " | ".join(conversion_methods),
+                "definition_note": "; ".join(definition_notes),
+            }
+        )
+
+    if not national_records:
+        return []
+
+    national_records.sort(key=lambda r: (r["iso3"], r["hazard_code"], r["metric"], r["source_id"], r["month"]))
+
+    rows: List[List[Any]] = []
+    ingested_at = _ingested_timestamp()
+    incident_flag = "on" if emit_incident else "off"
+
+    method_template = "mVAM; monthly-first; {conversion}; national roll-up; incident delta=" + incident_flag
+    definition_template = (
+        "WFP mVAM food insecurity indicators aggregated to monthly national counts. "
+        "Daily/weekly values are averaged to month prior to conversion. {note}"
+    )
+
+    if emit_stock:
+        for rec in national_records:
+            as_of = rec["month"]
+            value = rec["value"]
+            if value <= 0:
+                continue
+            digest = _digest([rec["iso3"], rec["hazard_code"], rec["metric"], as_of, value, rec["source_url"]])
+            year, month = as_of.split("-")
+            event_id = f"{rec['iso3']}-WFP-mVAM-{rec['hazard_code']}-{rec['metric']}-{year}-{month}-{digest}"
+            publication_date = f"{as_of}-01"
+            rows.append(
+                [
+                    event_id,
+                    rec.get("country_name", ""),
+                    rec["iso3"],
+                    rec["hazard_code"],
+                    rec["hazard_label"],
+                    rec["hazard_class"],
+                    rec["metric"],
+                    "stock",
+                    str(int(value)),
+                    DEFAULT_UNIT,
+                    as_of,
+                    publication_date,
+                    rec["publisher"],
+                    rec["source_type"],
+                    rec["source_url"],
+                    rec["doc_title"],
+                    definition_template.format(note=rec["definition_note"] or ""),
+                    method_template.format(conversion=rec["conversion_method"] or "people direct"),
+                    "",
+                    0,
+                    ingested_at,
+                ]
+            )
+
+    if emit_incident:
+        grouped: Dict[Tuple[str, str, str, str], List[Dict[str, Any]]] = {}
+        for rec in national_records:
+            key = (rec["iso3"], rec["hazard_code"], rec["metric"], rec["source_id"])
+            grouped.setdefault(key, []).append(rec)
+        for key, group in grouped.items():
+            group.sort(key=lambda r: r["month"])
+            prev_value: Optional[int] = None
+            for idx, rec in enumerate(group):
+                current = rec["value"]
+                as_of = rec["month"]
+                if prev_value is None:
+                    prev_value = current
+                    if include_first_month and current > 0:
+                        digest = _digest([rec["iso3"], rec["hazard_code"], rec["metric"], as_of, 0, rec["source_url"], "incident"])
+                        year, month = as_of.split("-")
+                        event_id = (
+                            f"{rec['iso3']}-WFP-mVAM-{rec['hazard_code']}-{rec['metric']}-{year}-{month}-incident-{digest}"
+                        )
+                        publication_date = f"{as_of}-01"
+                        rows.append(
+                            [
+                                event_id,
+                                rec.get("country_name", ""),
+                                rec["iso3"],
+                                rec["hazard_code"],
+                                rec["hazard_label"],
+                                rec["hazard_class"],
+                                rec["metric"],
+                                "incident",
+                                "0",
+                                DEFAULT_UNIT,
+                                as_of,
+                                publication_date,
+                                rec["publisher"],
+                                rec["source_type"],
+                                rec["source_url"],
+                                rec["doc_title"],
+                                definition_template.format(note=rec["definition_note"] or ""),
+                                method_template.format(conversion=rec["conversion_method"] or "people direct"),
+                                "",
+                                0,
+                                ingested_at,
+                            ]
+                        )
+                    continue
+                delta = current - prev_value
+                prev_value = current
+                if delta <= 0:
+                    continue
+                digest = _digest([rec["iso3"], rec["hazard_code"], rec["metric"], as_of, delta, rec["source_url"], "incident"])
+                year, month = as_of.split("-")
+                event_id = f"{rec['iso3']}-WFP-mVAM-{rec['hazard_code']}-{rec['metric']}-{year}-{month}-incident-{digest}"
+                publication_date = f"{as_of}-01"
+                rows.append(
+                    [
+                        event_id,
+                        rec.get("country_name", ""),
+                        rec["iso3"],
+                        rec["hazard_code"],
+                        rec["hazard_label"],
+                        rec["hazard_class"],
+                        rec["metric"],
+                        "incident",
+                        str(int(delta)),
+                        DEFAULT_UNIT,
+                        as_of,
+                        publication_date,
+                        rec["publisher"],
+                        rec["source_type"],
+                        rec["source_url"],
+                        rec["doc_title"],
+                        definition_template.format(note=rec["definition_note"] or ""),
+                        method_template.format(conversion=rec["conversion_method"] or "people direct"),
+                        "",
+                        0,
+                        ingested_at,
+                    ]
+                )
+
+    return rows
+
+
+def main() -> bool:
+    if os.getenv("RESOLVER_SKIP_WFP_MVAM") == "1":
+        dbg("RESOLVER_SKIP_WFP_MVAM=1 — skipping WFP mVAM connector")
+        _write_header_only(OUT_PATH)
+        return False
+
+    try:
+        rows = collect_rows()
+    except Exception as exc:
+        dbg(f"collect_rows failed: {exc}")
+        _write_header_only(OUT_PATH)
+        return False
+
+    if not rows:
+        dbg("no WFP mVAM rows collected; writing header only")
+        _write_header_only(OUT_PATH)
+        return False
+
+    _write_rows(rows, OUT_PATH)
+    print(f"wrote {OUT_PATH}")
+    return True
+
+
+if __name__ == "__main__":
+    main()

--- a/resolver/tests/test_connectors_headers.py
+++ b/resolver/tests/test_connectors_headers.py
@@ -59,6 +59,15 @@ def test_who_phe_header(tmp_path, monkeypatch):
     _assert_header(tmp_out)
 
 
+def test_wfp_mvam_header(tmp_path, monkeypatch):
+    monkeypatch.setenv("RESOLVER_SKIP_WFP_MVAM", "1")
+    mod = importlib.import_module("resolver.ingestion.wfp_mvam_client")
+    tmp_out = Path(tmp_path) / "wfp_mvam.csv"
+    mod.OUT_PATH = tmp_out
+    mod.main()
+    _assert_header(tmp_out)
+
+
 def test_dtm_header_written(tmp_path, monkeypatch):
     monkeypatch.setenv("RESOLVER_SKIP_DTM", "1")
     from resolver.ingestion import dtm_client

--- a/resolver/tests/test_wfp_mvam_monthly_delta.py
+++ b/resolver/tests/test_wfp_mvam_monthly_delta.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+
+import pandas as pd
+import yaml
+
+from resolver.ingestion import wfp_mvam_client
+
+
+def _run_connector(tmp_path: Path, monkeypatch, data: pd.DataFrame) -> pd.DataFrame:
+    data_path = tmp_path / "data.csv"
+    data.to_csv(data_path, index=False)
+
+    cfg = {
+        "sources": [
+            {
+                "name": "test-delta",
+                "kind": "csv",
+                "url": str(data_path),
+                "time_keys": ["date"],
+                "country_keys": ["iso3"],
+                "admin_keys": ["adm1"],
+                "people_keys": ["ifc_people"],
+                "driver_keys": ["driver"],
+                "series_hint": "stock",
+                "publisher": "WFP",
+                "source_type": "official",
+            }
+        ],
+        "allow_percent": False,
+        "prefer_hxl": False,
+        "indicator_priority": ["people_ifc"],
+        "shock_keywords": {"drought": ["drought"]},
+        "default_hazard": "multi",
+        "emit_stock": True,
+        "emit_incident": True,
+        "include_first_month_delta": False,
+    }
+
+    cfg_path = tmp_path / "config.yml"
+    with open(cfg_path, "w", encoding="utf-8") as fp:
+        yaml.safe_dump(cfg, fp)
+
+    out_path = tmp_path / "wfp_mvam.csv"
+    monkeypatch.setenv("RESOLVER_SKIP_WFP_MVAM", "0")
+    monkeypatch.setenv("WFP_MVAM_ALLOW_PERCENT", "0")
+    monkeypatch.setenv("WFP_MVAM_INCIDENT", "1")
+    monkeypatch.setenv("WFP_MVAM_STOCK", "1")
+    monkeypatch.delenv("WFP_MVAM_DENOMINATOR_FILE", raising=False)
+
+    monkeypatch.setattr(wfp_mvam_client, "CONFIG", cfg_path)
+    monkeypatch.setattr(wfp_mvam_client, "OUT_PATH", out_path)
+
+    wfp_mvam_client.main()
+
+    return pd.read_csv(out_path)
+
+
+def test_weekly_to_monthly_delta(tmp_path, monkeypatch):
+    data = pd.DataFrame(
+        [
+            {"date": "2024-01-07", "iso3": "KEN", "adm1": "National", "ifc_people": 100_000, "driver": "drought"},
+            {"date": "2024-02-07", "iso3": "KEN", "adm1": "National", "ifc_people": 110_000, "driver": "drought"},
+            {"date": "2024-02-21", "iso3": "KEN", "adm1": "National", "ifc_people": 130_000, "driver": "drought"},
+            {"date": "2024-03-05", "iso3": "KEN", "adm1": "National", "ifc_people": 100_000, "driver": "drought"},
+            {"date": "2024-03-20", "iso3": "KEN", "adm1": "National", "ifc_people": 90_000, "driver": "drought"},
+        ]
+    )
+
+    out = _run_connector(tmp_path, monkeypatch, data)
+    stock = out[out["series_semantics"] == "stock"].sort_values("as_of_date").reset_index(drop=True)
+    assert list(stock["as_of_date"]) == ["2024-01", "2024-02", "2024-03"]
+    assert [int(v) for v in stock["value"]] == [100000, 120000, 95000]
+
+    incident = out[out["series_semantics"] == "incident"]
+    incident_map = {row.as_of_date: int(row.value) for row in incident.itertuples()}
+    assert incident_map == {"2024-02": 20000}

--- a/resolver/tests/test_wfp_mvam_percent_to_count.py
+++ b/resolver/tests/test_wfp_mvam_percent_to_count.py
@@ -1,0 +1,143 @@
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+import yaml
+
+from resolver.ingestion import wfp_mvam_client
+
+
+SHOCK_KEYWORDS = {
+    "economic_crisis": ["inflation", "price"],
+    "drought": ["drought"],
+}
+
+
+def _write_config(tmp_path: Path, data_path: Path, allow_percent: bool, denom_path: Optional[Path] = None) -> Path:
+    cfg = {
+        "sources": [
+            {
+                "name": "test",
+                "kind": "csv",
+                "url": str(data_path),
+                "time_keys": ["date"],
+                "country_keys": ["iso3"],
+                "admin_keys": ["adm1"],
+                "pct_keys": ["ifc_pct"],
+                "people_keys": ["ifc_people"],
+                "population_keys": ["population"],
+                "driver_keys": ["driver"],
+                "series_hint": "stock",
+                "publisher": "WFP",
+                "source_type": "official",
+            }
+        ],
+        "allow_percent": allow_percent,
+        "prefer_hxl": False,
+        "indicator_priority": ["people_ifc", "ifc_pct"],
+        "shock_keywords": SHOCK_KEYWORDS,
+        "default_hazard": "multi",
+        "emit_stock": True,
+        "emit_incident": False,
+        "include_first_month_delta": False,
+    }
+    if denom_path is not None:
+        cfg["denominator_file"] = str(denom_path)
+    cfg_path = tmp_path / "config.yml"
+    with open(cfg_path, "w", encoding="utf-8") as fp:
+        yaml.safe_dump(cfg, fp)
+    return cfg_path
+
+
+def _run_connector(tmp_path: Path, monkeypatch, data: pd.DataFrame, *, allow_percent: bool, denom: Optional[pd.DataFrame] = None) -> pd.DataFrame:
+    data_path = tmp_path / "data.csv"
+    data.to_csv(data_path, index=False)
+
+    denom_path = None
+    if denom is not None:
+        denom_path = tmp_path / "denom.csv"
+        denom.to_csv(denom_path, index=False)
+
+    cfg_path = _write_config(tmp_path, data_path, allow_percent, denom_path)
+
+    out_path = tmp_path / "wfp_mvam.csv"
+    monkeypatch.setenv("RESOLVER_SKIP_WFP_MVAM", "0")
+    monkeypatch.setenv("WFP_MVAM_ALLOW_PERCENT", "1" if allow_percent else "0")
+    monkeypatch.setenv("WFP_MVAM_INCIDENT", "0")
+    monkeypatch.setenv("WFP_MVAM_STOCK", "1")
+    if denom_path is not None:
+        monkeypatch.setenv("WFP_MVAM_DENOMINATOR_FILE", str(denom_path))
+    else:
+        monkeypatch.delenv("WFP_MVAM_DENOMINATOR_FILE", raising=False)
+
+    monkeypatch.setattr(wfp_mvam_client, "CONFIG", cfg_path)
+    monkeypatch.setattr(wfp_mvam_client, "OUT_PATH", out_path)
+
+    wfp_mvam_client.main()
+
+    return pd.read_csv(out_path)
+
+
+def test_percent_with_dataset_population(tmp_path, monkeypatch):
+    data = pd.DataFrame(
+        [
+            {"date": "2024-01-05", "iso3": "KEN", "adm1": "North", "ifc_pct": 10, "population": 1000, "driver": "drought"},
+            {"date": "2024-01-19", "iso3": "KEN", "adm1": "North", "ifc_pct": 12, "population": 1000, "driver": "drought"},
+            {"date": "2024-01-10", "iso3": "KEN", "adm1": "South", "ifc_pct": 15, "population": 2000, "driver": "drought"},
+        ]
+    )
+
+    out = _run_connector(tmp_path, monkeypatch, data, allow_percent=True)
+    stock = out[out["series_semantics"] == "stock"].reset_index(drop=True)
+    assert not stock.empty
+    assert stock.loc[0, "hazard_code"] == "DR"
+    assert int(stock.loc[0, "value"]) == 410
+
+
+def test_percent_with_external_denominator(tmp_path, monkeypatch):
+    data = pd.DataFrame(
+        [
+            {"date": "2024-02-07", "iso3": "KEN", "adm1": "National", "ifc_pct": 15, "driver": "price surge"},
+        ]
+    )
+    denom = pd.DataFrame([
+        {"iso3": "KEN", "year": 2024, "population": 5000},
+    ])
+
+    out = _run_connector(tmp_path, monkeypatch, data, allow_percent=True, denom=denom)
+    stock = out[out["series_semantics"] == "stock"].reset_index(drop=True)
+    assert not stock.empty
+    assert int(stock.loc[0, "value"]) == 750
+
+
+def test_percent_rows_skipped_when_disallowed(tmp_path, monkeypatch):
+    data = pd.DataFrame(
+        [
+            {"date": "2024-03-01", "iso3": "KEN", "adm1": "North", "ifc_pct": 20, "driver": "drought"},
+        ]
+    )
+
+    out = _run_connector(tmp_path, monkeypatch, data, allow_percent=False)
+    stock = out[out["series_semantics"] == "stock"]
+    assert stock.empty
+
+
+def test_people_column_preferred_over_percent(tmp_path, monkeypatch):
+    data = pd.DataFrame(
+        [
+            {
+                "date": "2024-04-01",
+                "iso3": "KEN",
+                "adm1": "National",
+                "ifc_people": 2000,
+                "ifc_pct": 50,
+                "driver": "inflation"
+            },
+        ]
+    )
+
+    out = _run_connector(tmp_path, monkeypatch, data, allow_percent=True)
+    stock = out[out["series_semantics"] == "stock"].reset_index(drop=True)
+    assert not stock.empty
+    assert int(stock.loc[0, "value"]) == 2000
+    assert stock.loc[0, "hazard_code"] == "EC"

--- a/resolver/tests/test_wfp_mvam_shock_mapping.py
+++ b/resolver/tests/test_wfp_mvam_shock_mapping.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+
+import pandas as pd
+import yaml
+
+from resolver.ingestion import wfp_mvam_client
+
+
+KEYWORDS = {
+    "economic_crisis": ["inflation", "price"],
+    "drought": ["drought"],
+}
+
+
+def _run_connector(tmp_path: Path, monkeypatch, data: pd.DataFrame) -> pd.DataFrame:
+    data_path = tmp_path / "data.csv"
+    data.to_csv(data_path, index=False)
+
+    cfg = {
+        "sources": [
+            {
+                "name": "test-shocks",
+                "kind": "csv",
+                "url": str(data_path),
+                "time_keys": ["date"],
+                "country_keys": ["iso3"],
+                "admin_keys": ["adm1"],
+                "people_keys": ["ifc_people"],
+                "driver_keys": ["driver"],
+                "series_hint": "stock",
+                "publisher": "WFP",
+                "source_type": "official",
+            }
+        ],
+        "allow_percent": False,
+        "prefer_hxl": False,
+        "indicator_priority": ["people_ifc"],
+        "shock_keywords": KEYWORDS,
+        "default_hazard": "multi",
+        "emit_stock": True,
+        "emit_incident": False,
+        "include_first_month_delta": False,
+    }
+
+    cfg_path = tmp_path / "config.yml"
+    with open(cfg_path, "w", encoding="utf-8") as fp:
+        yaml.safe_dump(cfg, fp)
+
+    out_path = tmp_path / "wfp_mvam.csv"
+    monkeypatch.setenv("RESOLVER_SKIP_WFP_MVAM", "0")
+    monkeypatch.setenv("WFP_MVAM_ALLOW_PERCENT", "0")
+    monkeypatch.setenv("WFP_MVAM_INCIDENT", "0")
+    monkeypatch.setenv("WFP_MVAM_STOCK", "1")
+    monkeypatch.delenv("WFP_MVAM_DENOMINATOR_FILE", raising=False)
+
+    monkeypatch.setattr(wfp_mvam_client, "CONFIG", cfg_path)
+    monkeypatch.setattr(wfp_mvam_client, "OUT_PATH", out_path)
+
+    wfp_mvam_client.main()
+
+    return pd.read_csv(out_path)
+
+
+def test_shock_keyword_mapping(tmp_path, monkeypatch):
+    data = pd.DataFrame(
+        [
+            {"date": "2024-01-01", "iso3": "KEN", "adm1": "National", "ifc_people": 1_000, "driver": "Inflation pressure"},
+            {"date": "2024-02-01", "iso3": "KEN", "adm1": "National", "ifc_people": 1_200, "driver": "Drought update"},
+            {"date": "2024-03-01", "iso3": "KEN", "adm1": "National", "ifc_people": 1_400, "driver": "Inflation and drought impacts"},
+        ]
+    )
+
+    out = _run_connector(tmp_path, monkeypatch, data)
+    stock = out[out["series_semantics"] == "stock"].sort_values("as_of_date")
+
+    hazard_by_month = {row.as_of_date: row.hazard_code for row in stock.itertuples()}
+    assert hazard_by_month == {
+        "2024-01": "EC",
+        "2024-02": "DR",
+        "2024-03": "MULTI",
+    }
+
+    multi_row = stock[stock["as_of_date"] == "2024-03"].iloc[0]
+    assert multi_row["hazard_label"] == "Multi-driver Food Insecurity"

--- a/resolver/tools/precedence_config.yml
+++ b/resolver/tools/precedence_config.yml
@@ -1,7 +1,7 @@
 # Policy knobs (kept here so we don't hardcode in code)
 metric_preference: [in_need, affected]   # PIN first, else PA
 tiers:
-  - ["unhcr_api", "unhcr_odp", "ifrc_go", "who", "ipc", "dtm"]
+  - ["unhcr_api", "unhcr_odp", "ifrc_go", "who", "ipc", "wfp_mvam", "dtm"]
   - ["hdx", "emdat", "gdacs"]
   - ["reliefweb", "media"]
 source_precedence:                       # highest → lowest (legacy policy tiers)
@@ -62,3 +62,4 @@ lags:
   hdx: 3d
   emdat: 7d
   gdacs: 1d
+  wfp_mvam: 3d


### PR DESCRIPTION
## Summary
- implement a real WFP mVAM ingestion client with monthly-first rollups, percent-to-people conversion, and shock mapping
- add configuration, precedence tuning, and documentation updates for the new connector
- cover the connector with header, percent conversion, delta, and hazard keyword tests

## Testing
- pytest resolver/tests/test_wfp_mvam_percent_to_count.py resolver/tests/test_wfp_mvam_monthly_delta.py resolver/tests/test_wfp_mvam_shock_mapping.py
- pytest resolver/tests/test_connectors_headers.py

------
https://chatgpt.com/codex/tasks/task_e_68deb1ef0c38832c87ffbe383b7bd037