### PR TITLE
Fix mVAM percent conversion to avoid admin overcount

### DIFF
--- a/resolver/ingestion/config/wfp_mvam.yml
+++ b/resolver/ingestion/config/wfp_mvam.yml
@@ -16,6 +16,7 @@ sources:
 prefer_hxl: true
 monthly_first: true
 allow_percent: true
+suppress_admin_when_no_subpop: true
 denominator_file: "resolver/data/population.csv"
 indicator_priority: ["people_ifc", "ifc_pct", "rcsi"]
 


### PR DESCRIPTION
## Summary
- add a suppress_admin_when_no_subpop toggle so environments can prevent emitting per-admin conversions when percent rows have no local population data
- refactor the mVAM percent-to-people workflow to require admin populations, support national population-weighted conversion, or fall back to percent-only outputs when weights are missing
- carry denominator and aggregation context through national stock and incident records so downstream outputs explain how each value was derived

## Testing
- python -m compileall resolver/ingestion/wfp_mvam_client.py

------
https://chatgpt.com/codex/tasks/task_e_68df77318564832c84134809ff477698