### PR TITLE
Fix per-admin aggregation for mVAM mixed indicators

### DIFF
--- a/resolver/ingestion/config/wfp_mvam.yml
+++ b/resolver/ingestion/config/wfp_mvam.yml
@@ -16,6 +16,7 @@ sources:
 prefer_hxl: true
 monthly_first: true
 allow_percent: true
+# suppress admin-level conversions when no subpopulation weights are available
 suppress_admin_when_no_subpop: true
 denominator_file: "resolver/data/population.csv"
 indicator_priority: ["people_ifc", "ifc_pct", "rcsi"]


### PR DESCRIPTION
## Summary
- aggregate mixed mVAM indicators per admin so people data take precedence and percent data convert via admin populations when available
- add national fallbacks for percent-only datasets, including population-weighted conversion or percent outputs, while retaining the legacy override path
- document the suppress_admin_when_no_subpop configuration flag

## Testing
- python -m compileall resolver/ingestion/wfp_mvam_client.py

------
https://chatgpt.com/codex/tasks/task_e_68df7c833318832c8ab0df7a0409528f