### PR TITLE
Improve ingestion robustness for ACLED, GDACS, and EM-DAT

### DIFF
--- a/resolver/ingestion/config/acled.yml
+++ b/resolver/ingestion/config/acled.yml
@@ -1,4 +1,4 @@
-base_url: "https://api.acleddata.com"
+base_url: "https://api.acleddata.com/acled/read"
 window_days: 450
 limit: 1000
 keys:


### PR DESCRIPTION
## Summary
- update the ACLED configuration and client to call the JSON endpoint directly and validate payloads
- emit one GDACS event per ISO3 code by handling comma-separated or list country fields
- explicitly drop unsupported EM-DAT hazards so they are not misclassified as "other"

## Testing
- pytest resolver/tests/test_registries.py


------
https://chatgpt.com/codex/tasks/task_e_68df7f513ec0832cb6466396a00040ca