### PR TITLE
Connector gating and UNHCR/ODP hardening

### DIFF
--- a/resolver/ingestion/config/acled.yml
+++ b/resolver/ingestion/config/acled.yml
@@ -1,6 +1,7 @@
 base_url: "https://api.acleddata.com/acled/read"
 window_days: 450
 limit: 1000
+token: ""
 keys:
   date: ["event_date", "event_date_new", "date"]
   event_type: ["event_type"]

--- a/resolver/ingestion/config/ipc.yml
+++ b/resolver/ingestion/config/ipc.yml
@@ -1,28 +1,4 @@
-sources:
-  - name: ipc_global_rounds
-    kind: csv
-    url: https://example.com/ipc.csv
-    country_keys: ["iso3", "country", "adm0_name", "#country+code"]
-    period_start_keys: ["period_start", "start", "start_month", "#date+start", "#date"]
-    period_end_keys: ["period_end", "end", "end_month", "#date+end"]
-    phase3p_keys: ["phase3plus", "p3plus", "ipc3plus", "#population+phase+3plus", "#inneed"]
-    phase4p_keys: ["phase4plus", "ipc4plus", "#population+phase+4plus"]
-    phase5_keys: ["phase5", "#population+phase+5"]
-    drivers_keys: ["drivers", "driver", "hazard", "cause", "tags", "notes"]
-    title_keys: ["doc_title", "title"]
-    publication_keys: ["publication_date", "pub_date", "date"]
-    source_url_keys: ["source_url", "source", "url"]
-    publisher: "IPC"
-    source_type: "official"
-prefer_hxl: true
-monthly_first: true
-shock_keywords:
-  drought: ["drought", "dry spell", "rainfall deficit"]
-  flood: ["flood", "heavy rain", "inundation"]
-  armed_conflict_escalation: ["conflict", "insecurity", "violence", "hostilities", "armed"]
-  economic_crisis: ["economic", "inflation", "market", "prices", "currency", "livelihoods"]
-  phe: ["cholera", "measles", "outbreak", "epidemic", "pandemic"]
-emit_stock: true
-emit_incident: true
-include_first_month_delta: false
-default_hazard: multi
+enabled: false
+dayfirst: false
+feeds: []
+auth: {}

--- a/resolver/ingestion/config/unhcr.yml
+++ b/resolver/ingestion/config/unhcr.yml
@@ -2,6 +2,9 @@ base_url: "https://api.unhcr.org/population/v1/"
 user_agent: "spagbot-resolver/1.0 (github.com/kwyjad/Spagbot_metac-bot)"
 window_days: 60
 page_size: 500
+years_back: 3
+include_years: []
+page_limit: 500
 
 endpoints:
   # Use official public endpoint (docs show these resources)

--- a/resolver/ingestion/config/wfp_mvam_sources.yml
+++ b/resolver/ingestion/config/wfp_mvam_sources.yml
@@ -1,0 +1,3 @@
+enabled: false
+sources: []
+auth: {}

--- a/resolver/ingestion/config/who_phe.yml
+++ b/resolver/ingestion/config/who_phe.yml
@@ -1,23 +1,9 @@
-# Phase-1 WHO Public Health Emergency sources
+enabled: false
 sources:
-  - name: cholera_global
-    kind: csv
-    url: https://example.org/cholera_cases_by_week.csv
-    time_keys: ["week", "year"]
-    country_keys: ["iso3", "country", "country_code", "#country+code"]
-    case_keys: ["cases", "new_cases", "#affected+cases"]
+  cholera_global:
+    url: ""
     disease: cholera
-    series_hint: incident
-
-  - name: measles_global
-    kind: csv
-    url: https://example.org/measles_cases_by_week.csv
-    time_keys: ["week", "year"]
-    country_keys: ["iso3", "country", "country_code", "#country+code"]
-    case_keys: ["cases", "new_cases", "#affected+cases"]
+  measles_global:
+    url: ""
     disease: measles
-    series_hint: incident
-
-prefer_hxl: true
-monthly_first: true
-allow_first_month_delta: false
+auth: {}

--- a/resolver/ingestion/dtm_client.py
+++ b/resolver/ingestion/dtm_client.py
@@ -377,6 +377,9 @@ def main() -> bool:
 
     if not rows:
         dbg("no rows collected; writing header only")
+        print(
+            "DTM: 0 rows (no matching datasets or empty window). Configure datasets in config/dtm.yml"
+        )
         _write_header_only(OUT_PATH)
         return False
 

--- a/resolver/ingestion/who_phe_client.py
+++ b/resolver/ingestion/who_phe_client.py
@@ -58,6 +58,27 @@ HAZARD_CLASS = "health"
 
 DEBUG = os.getenv("RESOLVER_DEBUG", "0") == "1"
 
+DEFAULT_SOURCE_TEMPLATES: Dict[str, Dict[str, Any]] = {
+    "cholera_global": {
+        "name": "cholera_global",
+        "kind": "csv",
+        "time_keys": ["week", "year"],
+        "country_keys": ["iso3", "country", "country_code", "#country+code"],
+        "case_keys": ["cases", "new_cases", "#affected+cases"],
+        "disease": "cholera",
+        "series_hint": SERIES_INCIDENT,
+    },
+    "measles_global": {
+        "name": "measles_global",
+        "kind": "csv",
+        "time_keys": ["week", "year"],
+        "country_keys": ["iso3", "country", "country_code", "#country+code"],
+        "case_keys": ["cases", "new_cases", "#affected+cases"],
+        "disease": "measles",
+        "series_hint": SERIES_INCIDENT,
+    },
+}
+
 
 def dbg(message: str) -> None:
     if DEBUG:
@@ -80,10 +101,59 @@ def _env_bool(name: str, default: bool) -> bool:
 
 
 def load_config() -> Dict[str, Any]:
-    if not CONFIG.exists():
-        return {"sources": []}
-    with open(CONFIG, "r", encoding="utf-8") as fp:
-        return yaml.safe_load(fp) or {"sources": []}
+    raw: Dict[str, Any] = {"enabled": False, "sources": {}, "auth": {}}
+    if CONFIG.exists():
+        with open(CONFIG, "r", encoding="utf-8") as fp:
+            loaded = yaml.safe_load(fp) or {}
+        if isinstance(loaded, dict):
+            raw.update(loaded)
+
+    enabled = bool(raw.get("enabled", False))
+    auth_headers = raw.get("auth") if isinstance(raw.get("auth"), dict) else {}
+
+    configured_sources = raw.get("sources", {})
+    if isinstance(configured_sources, list):
+        merged: Dict[str, Any] = {}
+        for item in configured_sources:
+            if isinstance(item, dict) and item.get("name"):
+                merged[str(item["name"])]=item
+        configured_sources = merged
+    elif not isinstance(configured_sources, dict):
+        configured_sources = {}
+
+    sources: List[Dict[str, Any]] = []
+    for key, template in DEFAULT_SOURCE_TEMPLATES.items():
+        override = configured_sources.get(key)
+        if not override:
+            continue
+        url = ""
+        if isinstance(override, str):
+            url = override
+            override = {}
+        elif isinstance(override, dict):
+            url = str(override.get("url", ""))
+        if not url:
+            continue
+        source_cfg = dict(template)
+        source_cfg["url"] = url
+        if isinstance(override, dict):
+            for ok, ov in override.items():
+                if ok == "url":
+                    continue
+                source_cfg[ok] = ov
+        if auth_headers:
+            source_cfg.setdefault("headers", dict(auth_headers))
+        sources.append(source_cfg)
+
+    result: Dict[str, Any] = {
+        "enabled": enabled,
+        "sources": sources if enabled else [],
+        "auth": auth_headers,
+        "prefer_hxl": raw.get("prefer_hxl", True),
+        "monthly_first": raw.get("monthly_first", True),
+        "allow_first_month_delta": raw.get("allow_first_month_delta", False),
+    }
+    return result
 
 
 def load_countries() -> Tuple[pd.DataFrame, Dict[str, str], Dict[str, str]]:
@@ -267,12 +337,14 @@ def _detect_time_shape(time_keys: Sequence[str]) -> str:
     return "unknown"
 
 
-def _load_remote(url: str) -> io.BytesIO:
-    headers: Dict[str, str] = {}
+def _load_remote(url: str, *, headers: Optional[Dict[str, str]] = None) -> io.BytesIO:
+    merged_headers: Dict[str, str] = {}
+    if headers:
+        merged_headers.update({k: str(v) for k, v in headers.items()})
     ua = os.getenv("RELIEFWEB_APPNAME")
-    if ua:
-        headers["User-Agent"] = ua
-    resp = requests.get(url, headers=headers, timeout=60)
+    if ua and "User-Agent" not in merged_headers:
+        merged_headers["User-Agent"] = ua
+    resp = requests.get(url, headers=merged_headers or None, timeout=60)
     resp.raise_for_status()
     return io.BytesIO(resp.content)
 
@@ -285,7 +357,7 @@ def _load_frame(source: Dict[str, Any]) -> SourceFrame:
     buf: io.BytesIO | Path
     if url.startswith("http://") or url.startswith("https://"):
         dbg(f"fetching {url}")
-        buf = _load_remote(url)
+        buf = _load_remote(url, headers=source.get("headers"))
     else:
         path = Path(url)
         if not path.is_absolute():
@@ -483,8 +555,13 @@ def _write_rows(rows: Sequence[Dict[str, Any]], *, path: Path) -> None:
 
 def collect_rows() -> List[Dict[str, Any]]:
     cfg = load_config()
+    if not cfg.get("enabled", False):
+        print("WHO-PHE disabled via config; writing header-only CSV")
+        return []
+
     sources = cfg.get("sources", []) or []
     if not sources:
+        print("WHO-PHE enabled but no sources configured; writing header-only CSV")
         return []
 
     _, iso3_to_name, name_to_iso3 = load_countries()
@@ -525,6 +602,12 @@ def collect_rows() -> List[Dict[str, Any]]:
 
         try:
             frame = _load_frame(source)
+        except requests.HTTPError as exc:
+            print(f"[who_phe] source {name} returned {exc.response.status_code if exc.response else 'HTTPError'}; skipping")
+            continue
+        except requests.RequestException as exc:
+            print(f"[who_phe] source {name} request failed: {exc}")
+            continue
         except Exception as exc:
             dbg(f"source {name} failed to load: {exc}")
             continue


### PR DESCRIPTION
## Summary
- gate WHO PHE, WFP mVAM, and IPC collectors behind new config flags and empty-default endpoint files
- widen UNHCR asylum application pulls to multi-year pagination with clearer empty-results logging
- teach the UNHCR ODP scraper to discover widget IDs, deduplicate outputs, and add softer ACLED/DTM failure handling with runner summaries

## Testing
- python -m compileall resolver/ingestion

------
https://chatgpt.com/codex/tasks/task_e_68dfa8fe1674832c9b71d3df183b5443