### PR TITLE
Handle ReliefWeb WAF challenge with retries

### DIFF
--- a/resolver/ingestion/config/reliefweb.yml
+++ b/resolver/ingestion/config/reliefweb.yml
@@ -1,7 +1,10 @@
 appname: "UNICEF-Resolver-P1L1T6"
-user_agent: "spagbot-resolver/1.0 (github.com/kwyjad/Spagbot_metac-bot)"
+user_agent: "spagbot-resolver/1.0 (+https://github.com/kwyjad/Spagbot_metac-bot)"
 base_url: "https://api.reliefweb.int/v2/reports"
 accept_header: "application/json"
+max_retries: 5
+retry_backoff_seconds: 2
+timeout_seconds: 30
 window_days: 45
 page_size: 100
 


### PR DESCRIPTION
## Summary
- add ReliefWeb client configuration for appname, request headers, and retry/backoff parameters
- retry GET/POST requests when AWS WAF challenge responses are received and record challenge metrics
- ensure runs log summary rows/challenges and fall back to empty CSV when challenges persist

## Testing
- python -m compileall resolver/ingestion/reliefweb_client.py

------
https://chatgpt.com/codex/tasks/task_e_68dfd2835cb8832cb18abe2e42e01937