### PR TITLE
Add ACLED refresh-token auth helper and wire DTM API keys

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -149,3 +149,20 @@ MODEL_COSTS_JSON={
   "gemini-2.5-pro":{"prompt":1.25,"completion":10.0},
   "grok-4":{"prompt":3.0,"completion":15.0}
 }
+
+###############
+# RESOLVER CONNECTORS
+###############
+# ACLED credentials (prefer refresh token; helper exchanges it for a new access token)
+ACLED_REFRESH_TOKEN=
+# Optional fallbacks for manual authentication (avoid storing secrets when possible)
+# ACLED_USERNAME=
+# ACLED_PASSWORD=
+# Legacy override; if set, treated as an access token
+# ACLED_ACCESS_TOKEN=
+
+# IOM DTM API keys
+DTM_API_PRIMARY_KEY=
+DTM_API_SECONDARY_KEY=
+# Optional custom header name (defaults to x-api-key)
+# DTM_API_HEADER_NAME=

--- a/.github/workflows/resolver-ci.yml
+++ b/.github/workflows/resolver-ci.yml
@@ -21,6 +21,13 @@ jobs:
   pr_check:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    env:
+      ACLED_REFRESH_TOKEN: ${{ secrets.ACLED_REFRESH_TOKEN }}
+      ACLED_USERNAME: ${{ secrets.ACLED_USERNAME }}
+      ACLED_PASSWORD: ${{ secrets.ACLED_PASSWORD }}
+      DTM_API_PRIMARY_KEY: ${{ secrets.DTM_API_PRIMARY_KEY }}
+      DTM_API_SECONDARY_KEY: ${{ secrets.DTM_API_SECONDARY_KEY }}
+      DTM_API_HEADER_NAME: ${{ vars.DTM_API_HEADER_NAME }}
     steps:
       - name: Checkout (full)
         uses: actions/checkout@v4
@@ -146,6 +153,13 @@ jobs:
   nightly_state:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    env:
+      ACLED_REFRESH_TOKEN: ${{ secrets.ACLED_REFRESH_TOKEN }}
+      ACLED_USERNAME: ${{ secrets.ACLED_USERNAME }}
+      ACLED_PASSWORD: ${{ secrets.ACLED_PASSWORD }}
+      DTM_API_PRIMARY_KEY: ${{ secrets.DTM_API_PRIMARY_KEY }}
+      DTM_API_SECONDARY_KEY: ${{ secrets.DTM_API_SECONDARY_KEY }}
+      DTM_API_HEADER_NAME: ${{ vars.DTM_API_HEADER_NAME }}
     steps:
       - name: Checkout (full)
         uses: actions/checkout@v4

--- a/resolver/ingestion/acled_auth.py
+++ b/resolver/ingestion/acled_auth.py
@@ -1,0 +1,116 @@
+"""Helper utilities for authenticating against the ACLED API."""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import time
+import urllib.parse
+import urllib.request
+from typing import Dict, Optional
+
+_TOKEN_URL = "https://acleddata.com/oauth/token"
+_HEADERS = {"Content-Type": "application/x-www-form-urlencoded"}
+_CLIENT_ID = "acled"
+_MIN_TTL = 300  # seconds
+
+
+def _b64url_decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(value + padding)
+
+
+def _jwt_exp(token: str) -> Optional[int]:
+    try:
+        parts = token.split(".")
+        if len(parts) < 2:
+            return None
+        payload = json.loads(_b64url_decode(parts[1]).decode("utf-8"))
+    except Exception:
+        return None
+    exp = payload.get("exp")
+    try:
+        return int(exp) if exp is not None else None
+    except Exception:
+        return None
+
+
+def _jwt_is_valid(token: str, *, min_ttl: int = _MIN_TTL) -> bool:
+    exp = _jwt_exp(token)
+    if not exp:
+        return False
+    return (exp - int(time.time())) > min_ttl
+
+
+def _post(data: Dict[str, str]) -> Dict[str, str]:
+    body = urllib.parse.urlencode(data).encode("utf-8")
+    request = urllib.request.Request(_TOKEN_URL, data=body, headers=_HEADERS, method="POST")
+    with urllib.request.urlopen(request, timeout=30) as response:
+        payload = response.read().decode("utf-8")
+    return json.loads(payload)
+
+
+def _exchange_refresh(refresh_token: str) -> Dict[str, str]:
+    return _post(
+        {
+            "refresh_token": refresh_token,
+            "grant_type": "refresh_token",
+            "client_id": _CLIENT_ID,
+        }
+    )
+
+
+def _password_grant(username: str, password: str) -> Dict[str, str]:
+    return _post(
+        {
+            "username": username,
+            "password": password,
+            "grant_type": "password",
+            "client_id": _CLIENT_ID,
+        }
+    )
+
+
+def get_access_token() -> str:
+    """Return a valid ACLED access token, refreshing credentials when required."""
+
+    existing = os.environ.get("ACLED_ACCESS_TOKEN")
+    if existing and _jwt_is_valid(existing):
+        return existing
+
+    refresh_token = os.environ.get("ACLED_REFRESH_TOKEN")
+    if refresh_token:
+        tokens = _exchange_refresh(refresh_token)
+        access_token = tokens.get("access_token")
+        if not access_token:
+            raise RuntimeError("ACLED refresh grant response missing access_token")
+        new_refresh = tokens.get("refresh_token")
+        if new_refresh:
+            os.environ["ACLED_REFRESH_TOKEN"] = new_refresh
+        os.environ["ACLED_ACCESS_TOKEN"] = access_token
+        return access_token
+
+    username = os.environ.get("ACLED_USERNAME")
+    password = os.environ.get("ACLED_PASSWORD")
+    if username and password:
+        tokens = _password_grant(username, password)
+        access_token = tokens.get("access_token")
+        if not access_token:
+            raise RuntimeError("ACLED password grant response missing access_token")
+        new_refresh = tokens.get("refresh_token")
+        if new_refresh:
+            os.environ["ACLED_REFRESH_TOKEN"] = new_refresh
+        os.environ["ACLED_ACCESS_TOKEN"] = access_token
+        return access_token
+
+    raise RuntimeError(
+        "ACLED authentication failed: provide ACLED_REFRESH_TOKEN or "
+        "ACLED_USERNAME/ACLED_PASSWORD credentials."
+    )
+
+
+def get_auth_header() -> Dict[str, str]:
+    """Return an Authorization header for ACLED requests."""
+
+    token = get_access_token()
+    return {"Authorization": f"Bearer {token}"}

--- a/resolver/ingestion/dtm_client.py
+++ b/resolver/ingestion/dtm_client.py
@@ -81,6 +81,16 @@ def dbg(message: str) -> None:
         print(f"[dtm] {message}")
 
 
+def _dtm_headers() -> Dict[str, str]:
+    """Return API key headers for the DTM portal if credentials are configured."""
+
+    key = os.environ.get("DTM_API_PRIMARY_KEY") or os.environ.get("DTM_API_SECONDARY_KEY")
+    if not key:
+        return {}
+    header_name = os.environ.get("DTM_API_HEADER_NAME", "x-api-key")
+    return {header_name: key}
+
+
 def _env_bool(name: str, default: bool) -> bool:
     val = os.getenv(name)
     if val is None:


### PR DESCRIPTION
## Summary
- add an ACLED OAuth helper that refreshes access tokens and returns Authorization headers for the client
- update the ACLED client to rely on the helper and gracefully report auth issues while keeping legacy tokens as a fallback
- surface DTM API key headers, expose the secrets to CI, and document the new environment variables

## Testing
- python -m compileall resolver/ingestion/acled_auth.py resolver/ingestion/acled_client.py resolver/ingestion/dtm_client.py

------
https://chatgpt.com/codex/tasks/task_e_68dff7a415fc832c829500d96c4a91c9