### PR TITLE
Clamp WFP mVAM percentages and add smoke coverage

### DIFF
--- a/resolver/tests/test_wfp_mvam_monthly_delta.py
+++ b/resolver/tests/test_wfp_mvam_monthly_delta.py
@@ -40,6 +40,19 @@ def _run_connector(tmp_path: Path, monkeypatch, data: pd.DataFrame) -> pd.DataFr
     with open(cfg_path, "w", encoding="utf-8") as fp:
         yaml.safe_dump(cfg, fp)
 
+    overrides_path = tmp_path / "wfp_mvam_sources.yml"
+    overrides = {
+        "enabled": True,
+        "sources": [
+            {
+                "name": "test-delta",
+                "url": str(data_path),
+            }
+        ],
+    }
+    with open(overrides_path, "w", encoding="utf-8") as fp:
+        yaml.safe_dump(overrides, fp)
+
     out_path = tmp_path / "wfp_mvam.csv"
     monkeypatch.setenv("RESOLVER_SKIP_WFP_MVAM", "0")
     monkeypatch.setenv("WFP_MVAM_ALLOW_PERCENT", "0")
@@ -48,6 +61,7 @@ def _run_connector(tmp_path: Path, monkeypatch, data: pd.DataFrame) -> pd.DataFr
     monkeypatch.delenv("WFP_MVAM_DENOMINATOR_FILE", raising=False)
 
     monkeypatch.setattr(wfp_mvam_client, "CONFIG", cfg_path)
+    monkeypatch.setattr(wfp_mvam_client, "SOURCES_CONFIG", overrides_path)
     monkeypatch.setattr(wfp_mvam_client, "OUT_PATH", out_path)
 
     wfp_mvam_client.main()

--- a/resolver/tests/test_wfp_mvam_shock_mapping.py
+++ b/resolver/tests/test_wfp_mvam_shock_mapping.py
@@ -46,6 +46,19 @@ def _run_connector(tmp_path: Path, monkeypatch, data: pd.DataFrame) -> pd.DataFr
     with open(cfg_path, "w", encoding="utf-8") as fp:
         yaml.safe_dump(cfg, fp)
 
+    overrides_path = tmp_path / "wfp_mvam_sources.yml"
+    overrides = {
+        "enabled": True,
+        "sources": [
+            {
+                "name": "test-shocks",
+                "url": str(data_path),
+            }
+        ],
+    }
+    with open(overrides_path, "w", encoding="utf-8") as fp:
+        yaml.safe_dump(overrides, fp)
+
     out_path = tmp_path / "wfp_mvam.csv"
     monkeypatch.setenv("RESOLVER_SKIP_WFP_MVAM", "0")
     monkeypatch.setenv("WFP_MVAM_ALLOW_PERCENT", "0")
@@ -54,6 +67,7 @@ def _run_connector(tmp_path: Path, monkeypatch, data: pd.DataFrame) -> pd.DataFr
     monkeypatch.delenv("WFP_MVAM_DENOMINATOR_FILE", raising=False)
 
     monkeypatch.setattr(wfp_mvam_client, "CONFIG", cfg_path)
+    monkeypatch.setattr(wfp_mvam_client, "SOURCES_CONFIG", overrides_path)
     monkeypatch.setattr(wfp_mvam_client, "OUT_PATH", out_path)
 
     wfp_mvam_client.main()

--- a/resolver/tests/test_wfp_mvam_smoke.py
+++ b/resolver/tests/test_wfp_mvam_smoke.py
@@ -1,0 +1,18 @@
+"""Smoke test for WFP mVAM client import and collection."""
+
+import importlib
+from pathlib import Path
+
+
+def test_collect_rows_disabled_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("WFP_MVAM_ALLOW_PERCENT", "1")
+
+    config_path = tmp_path / "wfp_mvam_sources.yml"
+    config_path.write_text("enabled: false\nsources: []\n", encoding="utf-8")
+
+    client = importlib.import_module("resolver.ingestion.wfp_mvam_client")
+    monkeypatch.setattr(client, "SOURCES_CONFIG", Path(config_path))
+
+    rows = client.collect_rows()
+
+    assert rows == []


### PR DESCRIPTION
## Summary
- add `_clamp_pct` in the WFP mVAM client and use it throughout percent aggregation/conversion to guard against invalid values
- ensure percent-driven conversions are skipped when the clamped value is missing/negative to avoid propagating bad data
- create a smoke test for disabled overrides and update existing WFP mVAM tests to inject local override configs for end-to-end runs

## Testing
- `pytest resolver/tests/test_wfp_mvam_smoke.py resolver/tests/test_wfp_mvam_percent_to_count.py resolver/tests/test_wfp_mvam_monthly_delta.py resolver/tests/test_wfp_mvam_shock_mapping.py resolver/tests/test_wfp_mvam_with_worldpop.py resolver/tests/test_connectors_headers.py`
- `RESOLVER_INGESTION_MODE=stubs python resolver/ingestion/run_all_stubs.py`


------
https://chatgpt.com/codex/tasks/task_e_68dffb83db2c832c99f2aaa9444cf352