### PR TITLE
Add structured logging and retries to ingestion runner

### DIFF
--- a/.github/workflows/resolver-ci.yml
+++ b/.github/workflows/resolver-ci.yml
@@ -93,6 +93,15 @@ jobs:
           set -euxo pipefail
           python resolver/ingestion/run_all_stubs.py
 
+      - name: Upload ingestion logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ingestion-logs-${{ github.run_id }}
+          path: |
+            resolver/logs/ingestion/**
+            !resolver/logs/ingestion/**/.gitkeep
+
       - name: Export facts
         shell: bash
         run: |
@@ -224,6 +233,15 @@ jobs:
         run: |
           set -euxo pipefail
           python resolver/ingestion/run_all_stubs.py
+
+      - name: Upload ingestion logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ingestion-logs-${{ github.run_id }}
+          path: |
+            resolver/logs/ingestion/**
+            !resolver/logs/ingestion/**/.gitkeep
 
       - name: Export facts
         shell: bash

--- a/resolver/ingestion/README.md
+++ b/resolver/ingestion/README.md
@@ -55,6 +55,26 @@ python resolver/tools/validate_facts.py --facts resolver/exports/facts.csv
 python resolver/tools/freeze_snapshot.py --facts resolver/exports/facts.csv --month YYYY-MM
 ```
 
+### Structured logging & retries
+
+`run_all_stubs.py` now emits detailed run metadata and per-connector logs. Each run creates
+plain text and JSONL logs in `resolver/logs/ingestion/` (configurable via `RUNNER_LOG_DIR`).
+A subdirectory per run (named with the UTC start timestamp) contains per-connector logs, so
+`resolver/logs/ingestion/20250101-010203/ifrc_go_stub.log` holds only the IFRC stub output
+for that run.
+
+Key CLI switches:
+
+- `--connector foo --connector bar` — only run the selected connectors/stubs.
+- `--retries N` — retry flaky connectors with exponential backoff (defaults to `2`).
+- `--retry-base`, `--retry-max`, `--retry-no-jitter` — tune the retry backoff curve.
+- `--strict` — exit non-zero if any connector fails (default is soft-fail to keep CI green).
+- `--log-format plain|json`, `--log-level INFO|DEBUG|...` — tweak console verbosity.
+
+The logger also prints an environment summary (git commit, Python version, selected env
+flags) to help debug CI runs. Sensitive values (tokens, secrets, long random strings) are
+redacted automatically in both console and file output.
+
 ## IFRC GO (Admin v2) — real connector
 
 - **Endpoints:** Admin v2 (`https://goadmin.ifrc.org/api/v2/`) — see GO wiki and Swagger for details.  

--- a/resolver/ingestion/_retry.py
+++ b/resolver/ingestion/_retry.py
@@ -1,0 +1,85 @@
+"""Generic retry helper for ingestion connectors."""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import random
+import time
+from typing import Any, Callable, Optional
+
+RetryFunc = Callable[..., Any]
+RetryCondition = Callable[[BaseException], bool]
+
+
+_DEFAULT_RETRYABLE_NAMES = (
+    "Timeout",
+    "ConnectionError",
+    "SSLError",
+    "ReadTimeout",
+    "ChunkedEncodingError",
+)
+
+_DEFAULT_RETRYABLE_PHRASES = ("rate limit", "waf", "temporarily unavailable")
+
+
+def _default_is_retryable(exc: BaseException) -> bool:
+    exc_name = exc.__class__.__name__
+    if any(name in exc_name for name in _DEFAULT_RETRYABLE_NAMES):
+        return True
+    message = str(exc).lower()
+    return any(phrase in message for phrase in _DEFAULT_RETRYABLE_PHRASES)
+
+
+def retry_call(
+    func: RetryFunc,
+    *,
+    retries: int = 2,
+    base_delay: float = 1.0,
+    max_delay: float = 30.0,
+    jitter: bool = True,
+    is_retryable: Optional[RetryCondition] = None,
+    logger: Optional[logging.Logger | logging.LoggerAdapter] = None,
+    connector: Optional[str] = None,
+):
+    """Invoke ``func`` with retry and exponential backoff."""
+
+    condition = is_retryable or _default_is_retryable
+    attempts_allowed = max(0, retries)
+
+    signature = inspect.signature(func)
+    takes_attempt = len(signature.parameters) >= 1
+
+    last_exc: BaseException | None = None
+
+    for attempt in range(1, attempts_allowed + 2):
+        attempt_logger = logger
+        if isinstance(logger, logging.LoggerAdapter):
+            attempt_logger = logger
+        try:
+            if takes_attempt:
+                result = func(attempt)
+            else:
+                result = func()
+            return result
+        except Exception as exc:  # noqa: BLE001
+            last_exc = exc
+            should_retry = attempt <= attempts_allowed and condition(exc)
+            sleep_for = min(max_delay, base_delay * (2 ** (attempt - 1)))
+            if jitter:
+                sleep_for += random.uniform(0, sleep_for * 0.333)
+            if attempt_logger is not None:
+                payload = {
+                    "event": "retry",
+                    "attempt": attempt,
+                    "connector": connector,
+                    "retry": should_retry,
+                    "sleep": round(sleep_for, 3),
+                }
+                attempt_logger.warning("attempt failed", exc_info=exc, extra=payload)
+            if not should_retry:
+                raise
+            time.sleep(sleep_for)
+    if last_exc is not None:
+        raise last_exc
+    raise RuntimeError("retry_call exhausted without executing the callable")

--- a/resolver/ingestion/_runner_logging.py
+++ b/resolver/ingestion/_runner_logging.py
@@ -1,0 +1,333 @@
+"""Logging utilities for the ingestion runner."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+import time
+import traceback
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+DEFAULT_LOG_DIR = Path("resolver/logs/ingestion")
+
+
+@dataclass(frozen=True)
+class _RunnerContext:
+    run_id: str
+    log_dir: Path
+
+
+class _RunnerFormatter(logging.Formatter):
+    """Formatter that ensures UTC timestamps and runner metadata."""
+
+    converter = time.gmtime
+
+    def __init__(self, context: _RunnerContext) -> None:
+        super().__init__(
+            fmt="%(asctime)sZ [%(levelname)s] [run:%(run_id)s] [connector:%(connector)s] "
+            "attempt=%(attempt)s %(message)s"
+        )
+        self._context = context
+
+    def format(self, record: logging.LogRecord) -> str:  # noqa: D401
+        _apply_defaults(record, self._context)
+        return super().format(record)
+
+
+class _ConsoleJSONFormatter(logging.Formatter):
+    """Formatter that renders log records as JSON for stdout."""
+
+    converter = time.gmtime
+
+    def __init__(self, context: _RunnerContext) -> None:
+        super().__init__()
+        self._context = context
+
+    def format(self, record: logging.LogRecord) -> str:  # noqa: D401
+        _apply_defaults(record, self._context)
+        payload = {
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(record.created))
+            + f".{int(record.msecs):03d}Z",
+            "level": record.levelname,
+            "run_id": record.run_id,
+            "connector": record.connector,
+            "attempt": record.attempt,
+            "message": redact(record.getMessage()),
+        }
+        if record.__dict__:
+            extras = {
+                key: value
+                for key, value in record.__dict__.items()
+                if key not in {"run_id", "connector", "attempt", "msg", "args"}
+            }
+            if extras:
+                payload["extra"] = _jsonify(extras)
+        if record.exc_info:
+            payload["exc"] = redact("".join(traceback.format_exception(*record.exc_info)))
+        return json.dumps(payload, ensure_ascii=False)
+
+
+class _JSONLineHandler(logging.Handler):
+    """Write structured log records to a JSONL file."""
+
+    def __init__(self, path: Path, context: _RunnerContext) -> None:
+        super().__init__()
+        self._path = path
+        self._context = context
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Open in text mode with UTF-8 encoding so json is readable.
+        self._stream = path.open("a", encoding="utf-8")
+
+    def emit(self, record: logging.LogRecord) -> None:  # noqa: D401
+        try:
+            payload = self._build_payload(record)
+            json.dump(payload, self._stream, ensure_ascii=False, separators=(",", ":"))
+            self._stream.write("\n")
+            self._stream.flush()
+        except Exception:
+            self.handleError(record)
+
+    def _build_payload(self, record: logging.LogRecord) -> Dict[str, Any]:
+        ts = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(record.created))
+        payload: Dict[str, Any] = {
+            "ts": f"{ts}.{int(record.msecs):03d}Z",
+            "level": record.levelname,
+            "run_id": getattr(record, "run_id", self._context.run_id),
+            "connector": getattr(record, "connector", "-"),
+            "attempt": getattr(record, "attempt", 0),
+            "msg": redact(record.getMessage()),
+        }
+
+        extra = {
+            key: value
+            for key, value in record.__dict__.items()
+            if key
+            not in {
+                "name",
+                "msg",
+                "args",
+                "levelname",
+                "levelno",
+                "pathname",
+                "filename",
+                "module",
+                "exc_info",
+                "exc_text",
+                "stack_info",
+                "lineno",
+                "funcName",
+                "created",
+                "msecs",
+                "relativeCreated",
+                "thread",
+                "threadName",
+                "processName",
+                "process",
+                "run_id",
+                "connector",
+                "attempt",
+                "message",
+                "duration_ms",
+            }
+        }
+        if extra:
+            payload["extra"] = _jsonify(extra)
+
+        if record.exc_info:
+            payload["exc"] = redact("".join(traceback.format_exception(*record.exc_info)))
+        return payload
+
+    def close(self) -> None:  # noqa: D401
+        try:
+            self._stream.close()
+        finally:
+            super().close()
+
+
+def _jsonify(value: Any) -> Any:
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return redact(value) if isinstance(value, str) else value
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, dict):
+        return {str(k): _jsonify(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_jsonify(v) for v in value]
+    return redact(repr(value))
+
+
+_BASE_LOGGER: logging.Logger | None = None
+_CONTEXT: _RunnerContext | None = None
+_SENSITIVE_PATTERN = re.compile(r"[A-Za-z0-9_\-]{24,}")
+_SENSITIVE_VALUES: set[str] = set()
+
+
+def _apply_defaults(record: logging.LogRecord, context: _RunnerContext) -> None:
+    if not getattr(record, "run_id", None):
+        record.run_id = context.run_id  # type: ignore[attr-defined]
+    if getattr(record, "connector", None) in {None, ""}:
+        record.connector = "-"  # type: ignore[attr-defined]
+    if getattr(record, "attempt", None) in {None, ""}:
+        record.attempt = 0  # type: ignore[attr-defined]
+    if getattr(record, "duration_ms", None) in {None, ""}:
+        record.duration_ms = 0  # type: ignore[attr-defined]
+
+
+def _capture_sensitive_env() -> None:
+    global _SENSITIVE_VALUES
+    candidates = []
+    for key, value in os.environ.items():
+        upper = key.upper()
+        if any(token in upper for token in ("TOKEN", "KEY", "SECRET", "PASSWORD")) and value:
+            candidates.append(value)
+    _SENSITIVE_VALUES = {val for val in candidates if len(val) >= 8}
+
+
+def init_logger(
+    run_id: str,
+    level: str | None = None,
+    fmt: str | None = None,
+    log_dir: Path | None = None,
+) -> logging.Logger:
+    """Initialise the structured logger for ingestion runs."""
+
+    global _BASE_LOGGER, _CONTEXT
+
+    env_level = os.environ.get("RUNNER_LOG_LEVEL", "INFO")
+    env_format = os.environ.get("RUNNER_LOG_FORMAT", "plain")
+    env_dir = os.environ.get("RUNNER_LOG_DIR")
+
+    log_dir = Path(env_dir) if env_dir else (log_dir or DEFAULT_LOG_DIR)
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    chosen_level = (level or env_level).upper()
+    level_value = getattr(logging, chosen_level, logging.INFO)
+    chosen_format = (fmt or env_format).lower()
+
+    context = _RunnerContext(run_id=run_id, log_dir=log_dir)
+
+    logger = logging.getLogger("resolver.ingestion.runner")
+    logger.handlers.clear()
+    logger.setLevel(level_value)
+    logger.propagate = False
+
+    plain_formatter = _RunnerFormatter(context)
+
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setLevel(level_value)
+    if chosen_format == "json":
+        console_handler.setFormatter(_ConsoleJSONFormatter(context))
+    else:
+        console_handler.setFormatter(plain_formatter)
+    logger.addHandler(console_handler)
+
+    text_log = log_dir / f"ingest_{run_id}.log"
+    file_handler = logging.FileHandler(text_log, encoding="utf-8")
+    file_handler.setLevel(level_value)
+    file_handler.setFormatter(plain_formatter)
+    logger.addHandler(file_handler)
+
+    json_log = log_dir / f"ingest_{run_id}.jsonl"
+    json_handler = _JSONLineHandler(json_log, context)
+    json_handler.setLevel(level_value)
+    logger.addHandler(json_handler)
+
+    logger.run_id = run_id  # type: ignore[attr-defined]
+    logger.log_dir = log_dir  # type: ignore[attr-defined]
+    logger.json_log_path = json_log  # type: ignore[attr-defined]
+    logger.text_log_path = text_log  # type: ignore[attr-defined]
+
+    _BASE_LOGGER = logger
+    _CONTEXT = context
+    _capture_sensitive_env()
+    return logger
+
+
+def child_logger(connector_name: str) -> logging.LoggerAdapter:
+    if _BASE_LOGGER is None:
+        raise RuntimeError("init_logger must be called before child_logger")
+    return logging.LoggerAdapter(_BASE_LOGGER, {"connector": connector_name})
+
+
+def log_env_summary(logger: logging.Logger) -> None:
+    """Log runtime environment details to help with debugging."""
+
+    git_rev = _run_git(["rev-parse", "--short", "HEAD"])
+    git_branch = _run_git(["rev-parse", "--abbrev-ref", "HEAD"])
+    python_version = sys.version.replace("\n", " ")
+    platform = sys.platform
+    tokens = {
+        key: ("yes" if os.environ.get(key) else "no")
+        for key in sorted(os.environ)
+        if any(token in key.upper() for token in ("TOKEN", "KEY", "SECRET", "PASSWORD"))
+    }
+    summary = {
+        "event": "env_summary",
+        "git": {"rev": git_rev, "branch": git_branch},
+        "python": python_version,
+        "platform": platform,
+        "resolver_ci": os.environ.get("RESOLVER_CI", ""),
+        "disable_git_push": os.environ.get("DISABLE_GIT_PUSH", ""),
+        "tokens": tokens,
+    }
+    logger.info("environment", extra=summary)
+
+
+def _run_git(args: Iterable[str]) -> str:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            text=True,
+        )
+        output = result.stdout.strip()
+        return output if output else "unknown"
+    except Exception:
+        return "unavailable"
+
+
+def redact(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    masked = _SENSITIVE_PATTERN.sub("***", value)
+    for secret in _SENSITIVE_VALUES:
+        if secret:
+            masked = masked.replace(secret, "***")
+    return masked
+
+
+def connector_log_path(connector: str) -> Path:
+    if _CONTEXT is None:
+        raise RuntimeError("init_logger must be called before connector_log_path")
+    safe = connector.replace("/", "_")
+    path = _CONTEXT.log_dir / _CONTEXT.run_id / f"{safe}.log"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def attach_connector_handler(
+    logger: logging.LoggerAdapter | logging.Logger, connector: str
+) -> logging.Handler:
+    if _CONTEXT is None:
+        raise RuntimeError("init_logger must be called before attaching handlers")
+    base_logger = logger.logger if isinstance(logger, logging.LoggerAdapter) else logger
+    handler = logging.FileHandler(connector_log_path(connector), encoding="utf-8")
+    handler.setFormatter(_RunnerFormatter(_CONTEXT))
+    base_logger.addHandler(handler)
+    return handler
+
+
+def detach_connector_handler(
+    logger: logging.LoggerAdapter | logging.Logger, handler: logging.Handler
+) -> None:
+    base_logger = logger.logger if isinstance(logger, logging.LoggerAdapter) else logger
+    base_logger.removeHandler(handler)
+    handler.close()

--- a/resolver/ingestion/run_all_stubs.py
+++ b/resolver/ingestion/run_all_stubs.py
@@ -6,15 +6,33 @@ from __future__ import annotations
 import argparse
 import csv
 import datetime as dt
+import logging
 import os
 import subprocess
 import sys
+import time
+import warnings
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional, Sequence
+
+ROOT = Path(__file__).resolve().parent
+PROJECT_ROOT = ROOT.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
 import yaml
 
-ROOT = Path(__file__).resolve().parent
+from resolver.ingestion._retry import retry_call
+from resolver.ingestion._runner_logging import (
+    attach_connector_handler,
+    child_logger,
+    detach_connector_handler,
+    init_logger,
+    log_env_summary,
+    redact,
+)
+
 STAGING = ROOT.parent / "staging"
 CONFIG_DIR = ROOT / "config"
 
@@ -77,6 +95,62 @@ SUMMARY_TARGETS = {
     },
 }
 
+STUBS = [
+    "ifrc_go_stub.py",
+    "reliefweb_stub.py",
+    "unhcr_stub.py",
+    "hdx_stub.py",
+    "who_stub.py",
+    "ipc_stub.py",
+    "emdat_stub.py",
+    "gdacs_stub.py",
+    "copernicus_stub.py",
+    "unosat_stub.py",
+    "acled_stub.py",
+    "ucdp_stub.py",
+    "fews_stub.py",
+    "wfp_mvam_stub.py",
+    "gov_ndma_stub.py",
+]
+
+if FORCE_DTM_STUB:
+    REAL = [name for name in REAL if name != "dtm_client.py"]
+    if "dtm_stub.py" not in STUBS:
+        STUBS.insert(0, "dtm_stub.py")
+else:
+    STUBS = [name for name in STUBS if name != "dtm_stub.py"]
+
+SKIP_ENVS = {
+    "ifrc_go_client.py": ("RESOLVER_SKIP_IFRCGO", "IFRC GO connector"),
+    "reliefweb_client.py": ("RESOLVER_SKIP_RELIEFWEB", "ReliefWeb connector"),
+    "unhcr_client.py": ("RESOLVER_SKIP_UNHCR", "UNHCR connector"),
+    "unhcr_odp_client.py": ("RESOLVER_SKIP_UNHCR_ODP", "UNHCR ODP connector"),
+    "acled_client.py": ("RESOLVER_SKIP_ACLED", "ACLED connector"),
+    "dtm_client.py": ("RESOLVER_SKIP_DTM", "DTM connector"),
+    "emdat_client.py": ("RESOLVER_SKIP_EMDAT", "EM-DAT connector"),
+    "gdacs_client.py": ("RESOLVER_SKIP_GDACS", "GDACS connector"),
+    "who_phe_client.py": ("RESOLVER_SKIP_WHO", "WHO PHE connector"),
+    "ipc_client.py": ("RESOLVER_SKIP_IPC", "IPC connector"),
+    "hdx_client.py": ("RESOLVER_SKIP_HDX", "HDX connector"),
+    "worldpop_client.py": ("RESOLVER_SKIP_WORLDPOP", "WorldPop connector"),
+    "wfp_mvam_client.py": ("RESOLVER_SKIP_WFP_MVAM", "WFP mVAM connector"),
+}
+
+
+@dataclass
+class ConnectorSpec:
+    filename: str
+    path: Path
+    kind: str
+    output_path: Optional[Path] = None
+    summary: Optional[str] = None
+    skip_reason: Optional[str] = None
+    metadata: Dict[str, str] = field(default_factory=dict)
+
+    @property
+    def name(self) -> str:
+        return self.filename.rsplit(".", 1)[0]
+
 
 def _load_yaml(path: Optional[Path]) -> dict:
     if path is None or not path.exists():
@@ -86,8 +160,8 @@ def _load_yaml(path: Optional[Path]) -> dict:
     return data if isinstance(data, dict) else {}
 
 
-def _count_rows(path: Path) -> int:
-    if not path.exists():
+def _count_rows(path: Optional[Path]) -> int:
+    if not path or not path.exists():
         return 0
     try:
         with path.open("r", encoding="utf-8", newline="") as handle:
@@ -164,74 +238,137 @@ def _summarise_connector(name: str) -> str | None:
         parts.append(f"token:{'yes' if token_present else 'no'}")
     return " ".join(parts)
 
-STUBS = [
-    "ifrc_go_stub.py",
-    "reliefweb_stub.py",
-    "unhcr_stub.py",
-    "hdx_stub.py",
-    "who_stub.py",
-    "ipc_stub.py",
-    "emdat_stub.py",
-    "gdacs_stub.py",
-    "copernicus_stub.py",
-    "unosat_stub.py",
-    "acled_stub.py",
-    "ucdp_stub.py",
-    "fews_stub.py",
-    "wfp_mvam_stub.py",
-    "gov_ndma_stub.py",
-]
 
-if FORCE_DTM_STUB:
-    REAL = [name for name in REAL if name != "dtm_client.py"]
-    if "dtm_stub.py" not in STUBS:
-        STUBS.insert(0, "dtm_stub.py")
-else:
-    STUBS = [name for name in STUBS if name != "dtm_stub.py"]
-
-SKIP_ENVS = {
-    "ifrc_go_client.py": ("RESOLVER_SKIP_IFRCGO", "IFRC GO connector"),
-    "reliefweb_client.py": ("RESOLVER_SKIP_RELIEFWEB", "ReliefWeb connector"),
-    "unhcr_client.py": ("RESOLVER_SKIP_UNHCR", "UNHCR connector"),
-    "unhcr_odp_client.py": ("RESOLVER_SKIP_UNHCR_ODP", "UNHCR ODP connector"),
-    "acled_client.py": ("RESOLVER_SKIP_ACLED", "ACLED connector"),
-    "dtm_client.py": ("RESOLVER_SKIP_DTM", "DTM connector"),
-    "emdat_client.py": ("RESOLVER_SKIP_EMDAT", "EM-DAT connector"),
-    "gdacs_client.py": ("RESOLVER_SKIP_GDACS", "GDACS connector"),
-    "who_phe_client.py": ("RESOLVER_SKIP_WHO", "WHO PHE connector"),
-    "ipc_client.py": ("RESOLVER_SKIP_IPC", "IPC connector"),
-    "hdx_client.py": ("RESOLVER_SKIP_HDX", "HDX connector"),
-    "worldpop_client.py": ("RESOLVER_SKIP_WORLDPOP", "WorldPop connector"),
-    "wfp_mvam_client.py": ("RESOLVER_SKIP_WFP_MVAM", "WFP mVAM connector"),
-}
-
-
-def _should_skip(script: str) -> bool:
+def _should_skip(script: str) -> Optional[str]:
     env_name, label = SKIP_ENVS.get(script, (None, None))
     if env_name and os.environ.get(env_name) == "1":
-        print(f"{env_name}=1 — {label} will be skipped")
-        return True
-    return False
+        return f"{env_name}=1 — {label}"
+    return None
 
 
-def _run_script(path: Path) -> int:
-    print(f"==> running {path.name}")
+def _normalise_name(name: str) -> str:
+    name = name.strip()
+    if not name:
+        return name
+    if not name.endswith(".py"):
+        name = f"{name}.py"
+    return name
+
+
+def _build_specs(
+    real: Sequence[str],
+    stubs: Sequence[str],
+    selected: set[str] | None,
+    run_real: bool,
+    run_stubs: bool,
+) -> List[ConnectorSpec]:
+    specs: List[ConnectorSpec] = []
+    if run_real:
+        for filename in real:
+            if selected and filename not in selected:
+                continue
+            specs.append(_create_spec(filename, "real"))
+    if run_stubs:
+        for filename in stubs:
+            if selected and filename not in selected:
+                continue
+            specs.append(_create_spec(filename, "stub"))
+    return specs
+
+
+def _create_spec(filename: str, kind: str) -> ConnectorSpec:
+    path = ROOT / filename
+    meta = SUMMARY_TARGETS.get(filename, {})
+    summary = _summarise_connector(filename)
+    output_path = meta.get("staging") if isinstance(meta, dict) else None
+    skip_reason = None
+    skip_env = _should_skip(filename)
+    if not path.exists():
+        skip_reason = f"missing: {filename}"
+    elif skip_env:
+        skip_reason = skip_env
+    metadata: Dict[str, str] = {}
+    if output_path:
+        metadata["output_path"] = str(output_path)
+    return ConnectorSpec(
+        filename=filename,
+        path=path,
+        kind=kind,
+        output_path=output_path,
+        summary=summary,
+        skip_reason=skip_reason,
+        metadata=metadata,
+    )
+
+
+def _invoke_connector(path: Path) -> None:
     try:
-        proc = subprocess.run([sys.executable, str(path)])
-        return proc.returncode
-    except OSError as exc:
-        print(f"{path.name} failed to start: {exc}", file=sys.stderr)
-        return 1
+        proc = subprocess.run([sys.executable, str(path)], check=False)
+    except OSError as exc:  # pragma: no cover - defensive
+        raise RuntimeError(f"{path.name} failed to start: {exc}") from exc
+    if proc.returncode != 0:
+        raise subprocess.CalledProcessError(proc.returncode, [sys.executable, str(path)])
 
 
-def _safe_summary(name: str) -> None:
-    try:
-        summary_line = _summarise_connector(name)
-    except Exception as exc:  # pragma: no cover - defensive logging
-        print(f"[summary] {name} failed: {exc}", file=sys.stderr)
-        return
-    if summary_line:
-        print(summary_line)
+def _with_attempt_logger(
+    base: logging.LoggerAdapter | logging.Logger, attempt: int
+) -> logging.LoggerAdapter:
+    if isinstance(base, logging.LoggerAdapter):
+        extra = dict(base.extra)
+        logger = base.logger
+    else:
+        extra = {}
+        logger = base
+    extra["attempt"] = attempt
+    return logging.LoggerAdapter(logger, extra)
+
+
+def _render_summary_table(rows: List[Dict[str, object]]) -> str:
+    headers = ["Connector", "Status", "Attempts", "Rows", "Duration(ms)", "Notes"]
+    table_rows = [
+        [
+            row.get("name", ""),
+            row.get("status", ""),
+            str(row.get("attempts", "")),
+            str(row.get("rows", "")),
+            str(row.get("duration_ms", "")),
+            row.get("notes", "") or "",
+        ]
+        for row in rows
+    ]
+    if not table_rows:
+        table_rows = [["-", "-", "0", "0", "0", ""]]
+    columns = list(zip(headers, *table_rows))
+    widths = [max(len(str(value)) for value in column) for column in columns]
+    lines = []
+    header_line = " | ".join(header.ljust(width) for header, width in zip(headers, widths))
+    lines.append(header_line)
+    lines.append("-+-".join("-" * width for width in widths))
+    for row in table_rows:
+        lines.append(" | ".join(str(value).ljust(width) for value, width in zip(row, widths)))
+    return "\n".join(lines)
+
+
+def _rows_written(before: int, after: int) -> int:
+    return max(0, after - before)
+
+
+def _run_connector(spec: ConnectorSpec, logger: logging.LoggerAdapter) -> Dict[str, object]:
+    start = time.perf_counter()
+    rows_before = _count_rows(spec.output_path)
+    _invoke_connector(spec.path)
+    rows_after = _count_rows(spec.output_path)
+    duration_ms = int((time.perf_counter() - start) * 1000)
+    logger.info(
+        "completed",
+        extra={
+            "event": "completed",
+            "duration_ms": duration_ms,
+            "rows_written": _rows_written(rows_before, rows_after),
+            "rows_total": rows_after,
+        },
+    )
+    return {"status": "ok", "rows": rows_after, "duration_ms": duration_ms}
 
 
 def _parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
@@ -241,75 +378,238 @@ def _parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         action="store_true",
         help="treat connector/stub failures as fatal (non-zero exit)",
     )
-    return parser.parse_args(argv or [])
+    parser.add_argument("--retries", type=int, default=2, help="number of retries per connector")
+    parser.add_argument("--retry-base", type=float, default=1.0, help="initial retry delay in seconds")
+    parser.add_argument("--retry-max", type=float, default=30.0, help="maximum retry delay in seconds")
+    parser.add_argument(
+        "--retry-no-jitter",
+        action="store_true",
+        help="disable jitter for retry backoff",
+    )
+    parser.add_argument(
+        "--connector",
+        action="append",
+        default=[],
+        help="limit run to specific connector(s) (filename without .py or with)",
+    )
+    parser.add_argument(
+        "--log-format",
+        choices=("plain", "json"),
+        default=None,
+        help="console log format (defaults to RUNNER_LOG_FORMAT)",
+    )
+    parser.add_argument(
+        "--log-level",
+        default=None,
+        help="log level (defaults to RUNNER_LOG_LEVEL or INFO)",
+    )
+    if argv is None:
+        return parser.parse_args()
+    return parser.parse_args(argv)
 
 
 def main(argv: Optional[List[str]] = None) -> int:
     args = _parse_args(argv)
-    strict_mode = bool(args.strict)
+    root_input = sys.argv if argv is None else ['<custom>'] + list(argv)
+    requested = { _normalise_name(name) for name in args.connector if name }
+    selected: Optional[set[str]] = requested or None
+
+    run_id = dt.datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+    root = init_logger(run_id, level=args.log_level, fmt=args.log_format, log_dir=None)
+    log_env_summary(root)
+    root.info(
+        "parsed arguments",
+        extra={
+            "event": "args",
+            "connector_args": list(args.connector),
+            "raw_argv": root_input[1:],
+        },
+    )
+
+    warnings.simplefilter("default")
+
+    def _warn_to_log(message, category, filename, lineno, file=None, line=None):  # type: ignore[override]
+        root.warning(
+            f"{category.__name__}: {message}",
+            extra={"event": "warning", "filename": filename, "lineno": lineno},
+        )
+
+    warnings.showwarning = _warn_to_log  # type: ignore[assignment]
 
     if INGESTION_MODE and INGESTION_MODE not in {"real", "stubs", "all"}:
-        print(
-            f"Unknown RESOLVER_INGESTION_MODE={INGESTION_MODE!r}; expected one of real|stubs|all"
+        root.error(
+            "Unknown RESOLVER_INGESTION_MODE=%s; expected one of real|stubs|all",
+            INGESTION_MODE,
+            extra={"event": "config_error"},
         )
         return 0
 
+    real_list = list(REAL)
+    stub_list = list(STUBS)
+    real_set = set(real_list)
+    stub_set = set(stub_list)
+
+    run_real = True
+    run_stubs = INCLUDE_STUBS
     if INGESTION_MODE:
         run_real = INGESTION_MODE in {"real", "all"}
         run_stubs = INGESTION_MODE in {"stubs", "all"}
-    else:
-        run_real = True
-        run_stubs = INCLUDE_STUBS
-
     if FORCE_DTM_STUB:
         run_stubs = True
 
-    real_failures = 0
-    if run_real:
-        for name in REAL:
-            path = ROOT / name
-            if _should_skip(name):
+    if selected is not None:
+        unknown = selected - real_set - stub_set
+        if unknown:
+            for name in sorted(unknown):
+                root.warning("Requested connector %s is unknown", name, extra={"event": "unknown_connector"})
+            selected -= unknown
+        if not selected:
+            root.info("No known connectors requested; exiting", extra={"event": "no_connectors"})
+            return 0
+        run_real = any(name in real_set for name in selected)
+        run_stubs = any(name in stub_set for name in selected)
+
+    specs = _build_specs(real_list, stub_list, selected, run_real, run_stubs)
+    root.info(
+        "planning run",
+        extra={
+            "event": "plan",
+            "requested": sorted(requested),
+            "run_real": run_real,
+            "run_stubs": run_stubs,
+            "count": len(specs),
+        },
+    )
+    if requested:
+        specs = [spec for spec in specs if spec.filename in requested]
+    if not specs:
+        root.info("No connectors to run", extra={"event": "no_connectors"})
+        return 0
+
+    connectors_summary: List[Dict[str, object]] = []
+    total_start = time.perf_counter()
+
+    for spec in specs:
+        child = child_logger(spec.name)
+        handler = attach_connector_handler(child, spec.name)
+        attempts = 0
+        rows = 0
+        status = "skipped"
+        notes: Optional[str] = None
+        connector_start = time.perf_counter()
+        try:
+            if spec.skip_reason:
+                child.warning(
+                    "skipped",
+                    extra={"event": "skipped", "reason": redact(spec.skip_reason)},
+                )
+                notes = spec.skip_reason
+                status = "skipped"
+                attempts = 0
+                rows = 0
                 continue
-            if not path.exists():
-                print(f"{name} missing; skipping", file=sys.stderr)
-                continue
-            rc = _run_script(path)
-            if rc != 0:
-                print(f"{name} failed with rc={rc}", file=sys.stderr)
-                real_failures += 1
 
-        for summary_name in SUMMARY_TARGETS:
-            if summary_name in REAL:
-                _safe_summary(summary_name)
+            def _attempt(attempt: int) -> Dict[str, object]:
+                nonlocal attempts
+                attempts = max(attempts, attempt)
+                attempt_logger = _with_attempt_logger(child, attempt)
+                start_extra = {
+                    "event": "start",
+                    "attempt": attempt,
+                    "kind": spec.kind,
+                    "path": str(spec.path),
+                }
+                for key, value in spec.metadata.items():
+                    start_extra[key] = redact(value)
+                if spec.summary:
+                    start_extra["summary"] = redact(spec.summary)
+                attempt_logger.info("starting", extra=start_extra)
+                return _run_connector(spec, attempt_logger)
 
-    if not run_stubs:
-        return 1 if (strict_mode and real_failures) else 0
+            result = retry_call(
+                _attempt,
+                retries=max(0, args.retries),
+                base_delay=args.retry_base,
+                max_delay=args.retry_max,
+                jitter=not args.retry_no_jitter,
+                logger=child,
+                connector=spec.name,
+            )
+            rows = int(result.get("rows", 0))
+            duration_ms = int((time.perf_counter() - connector_start) * 1000)
+            if spec.output_path and spec.output_path.exists() and rows == 0:
+                status = "ok-empty"
+                notes = "header-only"
+            else:
+                status = "ok"
+            child.info(
+                "finished",
+                extra={
+                    "event": "finished",
+                    "status": status,
+                    "rows": rows,
+                    "attempts": attempts,
+                    "duration_ms": duration_ms,
+                    "notes": redact(notes) if notes else None,
+                },
+            )
+        except Exception as exc:  # noqa: BLE001
+            duration_ms = int((time.perf_counter() - connector_start) * 1000)
+            status = "error"
+            notes = redact(str(exc))
+            rows = 0
+            if attempts == 0:
+                attempts = 1
+            child.error(
+                "failed",
+                exc_info=exc,
+                extra={
+                    "event": "error",
+                    "rows": rows,
+                    "attempts": attempts,
+                    "duration_ms": duration_ms,
+                },
+            )
+        finally:
+            detach_connector_handler(child, handler)
+            connectors_summary.append(
+                {
+                    "name": spec.name,
+                    "status": status,
+                    "attempts": attempts,
+                    "rows": rows,
+                    "duration_ms": int((time.perf_counter() - connector_start) * 1000),
+                    "notes": redact(notes) if notes else None,
+                    "kind": spec.kind,
+                }
+            )
 
-    stub_failures = 0
-    for name in STUBS:
-        if FORCE_DTM_STUB and not INCLUDE_STUBS and name != "dtm_stub.py":
-            continue
-        path = ROOT / name
-        if not path.exists():
-            print(f"{name} missing; skipping", file=sys.stderr)
-            continue
-        rc = _run_script(path)
-        if rc != 0:
-            print(f"{name} failed with rc={rc}", file=sys.stderr)
-            stub_failures += 1
+    total_duration_ms = int((time.perf_counter() - total_start) * 1000)
+    table = _render_summary_table(connectors_summary)
+    root.info("Connector summary\n%s", table, extra={"event": "summary_table"})
+    root.info(
+        "run complete",
+        extra={
+            "event": "run_summary",
+            "run_id": run_id,
+            "connectors": [
+                {key: value for key, value in entry.items() if key != "kind"}
+                for entry in connectors_summary
+            ],
+            "total_duration_ms": total_duration_ms,
+        },
+    )
 
-    if stub_failures:
-        print(f"{stub_failures} stub(s) failed", file=sys.stderr)
-    else:
-        print("All stubs ran successfully")
+    real_failures = sum(
+        1 for entry in connectors_summary if entry.get("kind") == "real" and entry.get("status") == "error"
+    )
+    stub_failures = sum(
+        1 for entry in connectors_summary if entry.get("kind") == "stub" and entry.get("status") == "error"
+    )
 
-    strict_failures = 0
-    if strict_mode and (real_failures or stub_failures):
-        strict_failures = real_failures + stub_failures
-    elif FAIL_ON_STUB_ERROR and stub_failures:
-        strict_failures = stub_failures
-
-    if strict_failures:
+    if args.strict and (real_failures or stub_failures):
+        return 1
+    if FAIL_ON_STUB_ERROR and stub_failures:
         return 1
     return 0
 

--- a/resolver/tests/test_run_all_stubs_logging.py
+++ b/resolver/tests/test_run_all_stubs_logging.py
@@ -1,0 +1,59 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "ingestion" / "run_all_stubs.py"
+
+
+@pytest.mark.allow_network
+def test_run_all_stubs_creates_structured_logs(tmp_path):
+    log_dir = tmp_path / "logs"
+    env = os.environ.copy()
+    env.update(
+        {
+            "RUNNER_LOG_DIR": str(log_dir),
+            "RESOLVER_INCLUDE_STUBS": "1",
+            "RUNNER_LOG_LEVEL": "INFO",
+            "RESOLVER_INGESTION_MODE": "stubs",
+        }
+    )
+    project_root = str(SCRIPT.parents[2])
+    existing_path = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = (
+        f"{project_root}:{existing_path}" if existing_path else project_root
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--connector",
+            "ifrc_go_stub",
+            "--retries",
+            "1",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    log_files = sorted(log_dir.glob("ingest_*.log"))
+    jsonl_files = sorted(log_dir.glob("ingest_*.jsonl"))
+    assert log_files, "expected plain log output"
+    assert jsonl_files, "expected jsonl log output"
+
+    run_id = log_files[0].stem.split("_", 1)[1]
+    connector_log = log_dir / run_id / "ifrc_go_stub.log"
+    assert connector_log.exists(), "expected per-connector log file"
+
+    with jsonl_files[0].open("r", encoding="utf-8") as handle:
+        records = [json.loads(line) for line in handle if line.strip()]
+
+    assert any(rec.get("extra", {}).get("event") == "run_summary" for rec in records)


### PR DESCRIPTION
## Summary
- add a reusable ingestion logging helper that emits console, text, and JSONL output with redaction support
- refactor the ingestion runner to use structured logging, configurable retries, and per-connector summaries
- add a smoke test for log creation and publish ingestion logs from CI runs

## Testing
- pytest resolver/tests/test_run_all_stubs_logging.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dffe720784832c899365af4e21f266