### PR TITLE
Restore ingestion failure exit behavior and accept legacy ACLED tokens

### DIFF
--- a/.github/workflows/resolver-ci.yml
+++ b/.github/workflows/resolver-ci.yml
@@ -80,7 +80,7 @@ jobs:
           WORLDPOP_PRODUCT: "un_adj_unconstrained"
         run: |
           set -euxo pipefail
-          python resolver/ingestion/run_all_stubs.py
+          python resolver/ingestion/run_all_stubs.py --mode real --run-stubs=0 --strict
 
       - name: Run stubs (non-blocking)
         if: ${{ always() }}

--- a/resolver/tests/test_acled_auth_tokens.py
+++ b/resolver/tests/test_acled_auth_tokens.py
@@ -1,0 +1,66 @@
+import importlib
+import os
+
+import resolver.ingestion.acled_auth as acled_auth_module
+
+_ENV_VARS = [
+    "ACLED_ACCESS_TOKEN",
+    "ACLED_TOKEN",
+    "ACLED_REFRESH_TOKEN",
+    "ACLED_USERNAME",
+    "ACLED_PASSWORD",
+]
+
+
+def _reload(monkeypatch, **env):
+    for name in _ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    module = importlib.reload(acled_auth_module)
+    return module
+
+
+def test_get_access_token_accepts_opaque_token(monkeypatch):
+    module = _reload(monkeypatch, ACLED_ACCESS_TOKEN="opaque-token")
+
+    def _fail(*_args, **_kwargs):  # pragma: no cover - defensive helper
+        raise AssertionError("refresh/password grant should not run for opaque tokens")
+
+    monkeypatch.setattr(module, "_exchange_refresh", _fail)
+    monkeypatch.setattr(module, "_password_grant", _fail)
+
+    token = module.get_access_token()
+
+    assert token == "opaque-token"
+
+
+def test_get_access_token_uses_legacy_env_var(monkeypatch):
+    module = _reload(monkeypatch, ACLED_TOKEN="legacy-token")
+
+    token = module.get_access_token()
+
+    assert token == "legacy-token"
+    assert os.environ.get("ACLED_ACCESS_TOKEN") == "legacy-token"
+
+
+def test_invalid_access_token_refreshes_when_possible(monkeypatch):
+    module = _reload(
+        monkeypatch,
+        ACLED_ACCESS_TOKEN="expired-token",
+        ACLED_REFRESH_TOKEN="refresh-123",
+    )
+
+    monkeypatch.setattr(module, "_jwt_is_valid", lambda _token: False)
+
+    def _fake_refresh(refresh_token: str):
+        assert refresh_token == "refresh-123"
+        return {"access_token": "new-token", "refresh_token": "new-refresh"}
+
+    monkeypatch.setattr(module, "_exchange_refresh", _fake_refresh)
+
+    token = module.get_access_token()
+
+    assert token == "new-token"
+    assert os.environ.get("ACLED_ACCESS_TOKEN") == "new-token"
+    assert os.environ.get("ACLED_REFRESH_TOKEN") == "new-refresh"


### PR DESCRIPTION
## Summary
- ensure the ingestion runner fails on real connector errors by default in real-only mode, adds CLI overrides, and protects connector summaries
- update ACLED auth to accept legacy tokens, prefer refresh flows when available, and cover the scenarios with new tests
- invoke the runner in CI with explicit real-mode strict flags to enforce failure propagation

## Testing
- pytest resolver/tests/test_runner_modes.py resolver/tests/test_acled_auth_tokens.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e006e68300832cadde0ce53f593a4e