### PR TITLE
Handle subprocess failures in connector retries

### DIFF
--- a/resolver/ingestion/_retry.py
+++ b/resolver/ingestion/_retry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import inspect
 import logging
 import random
+import subprocess
 import time
 from typing import Any, Callable, Optional
 
@@ -64,22 +65,53 @@ def retry_call(
             return result
         except Exception as exc:  # noqa: BLE001
             last_exc = exc
+            exit_code = getattr(exc, "returncode", None)
+            stderr_text = ""
+            stdout_text = ""
+            try:
+                if hasattr(exc, "stderr") and getattr(exc, "stderr"):
+                    raw_stderr = getattr(exc, "stderr")
+                    if isinstance(raw_stderr, (bytes, bytearray)):
+                        stderr_text = raw_stderr.decode(errors="ignore")
+                    else:
+                        stderr_text = str(raw_stderr)
+                if hasattr(exc, "stdout") and getattr(exc, "stdout"):
+                    raw_stdout = getattr(exc, "stdout")
+                    if isinstance(raw_stdout, (bytes, bytearray)):
+                        stdout_text = raw_stdout.decode(errors="ignore")
+                    else:
+                        stdout_text = str(raw_stdout)
+            except Exception:  # noqa: BLE001
+                stderr_text = ""
+                stdout_text = ""
+            if isinstance(exc, subprocess.CalledProcessError):
+                exit_code = exc.returncode
+
             should_retry = attempt <= attempts_allowed and condition(exc)
-            sleep_for = min(max_delay, base_delay * (2 ** (attempt - 1)))
-            if jitter:
-                sleep_for += random.uniform(0, sleep_for * 0.333)
+            backoff = 0.0
+            if should_retry and attempt <= attempts_allowed:
+                backoff = min(max_delay, base_delay * (2 ** (attempt - 1)))
+                if jitter:
+                    backoff += random.uniform(0, backoff * 0.333)
             if attempt_logger is not None:
                 payload = {
                     "event": "retry",
                     "attempt": attempt,
                     "connector": connector,
                     "retry": should_retry,
-                    "sleep": round(sleep_for, 3),
+                    "sleep": round(backoff, 3),
                 }
+                if exit_code is not None:
+                    payload["exit_code"] = exit_code
+                if stderr_text:
+                    payload["stderr_excerpt"] = stderr_text[:200]
+                if stdout_text:
+                    payload["stdout_excerpt"] = stdout_text[:200]
                 attempt_logger.warning("attempt failed", exc_info=exc, extra=payload)
             if not should_retry:
                 raise
-            time.sleep(sleep_for)
+            if backoff > 0:
+                time.sleep(backoff)
     if last_exc is not None:
         raise last_exc
     raise RuntimeError("retry_call exhausted without executing the callable")


### PR DESCRIPTION
## Summary
- add retry heuristics for connector subprocess failures, including exit-code and stderr analysis
- wire the ingestion runner to use the new retry predicate and expand retry attempt logging details

## Testing
- python -m compileall resolver/ingestion

------
https://chatgpt.com/codex/tasks/task_e_68e00ad36188832cbb01a200822a838a