### PR TITLE
Implement configurable ACLED conflict onset rule

### DIFF
--- a/resolver/ingestion/config/acled.yml
+++ b/resolver/ingestion/config/acled.yml
@@ -11,6 +11,11 @@ keys:
   fatalities: ["fatalities", "#affected+killed", "#fatalities"]
   notes: ["notes", "description"]
 unrest_types: ["Protests", "Riots"]
+onset:
+  enabled: true
+  battle_event_types: ["Battles"]
+  lookback_months: 12
+  threshold_battle_deaths: 25
 participants:
   enabled: false
   regex: "(?:participants?|protesters?)\\D{0,10}([0-9][0-9,\\.]+)"

--- a/resolver/policy/resolution_policy.md
+++ b/resolver/policy/resolution_policy.md
@@ -50,6 +50,15 @@ If eligible figures differ by **>20%**:
 - If same tier, pick the **newest as-of** date (then latest publication date).
 - Record the discarded value in `alt_value` + `alt_source_url`; add a short note in `precedence_decision`.
 
+### Conflict Onset Rule (ACLED ingestion)
+For ACLED-derived conflict monitoring we apply an explicit **conflict onset** rule in addition to standard escalation checks:
+
+- Track **battle fatalities** each month for every ISO3 country code, counting only ACLED events whose `event_type` is in the configurable `onset.battle_event_types` list (default: `Battles`).
+- Compute the rolling sum of battle fatalities over the **previous 12 months**, excluding the current month. Missing months are treated as zero so gaps do not break the window.
+- When the previous-12-month total is **< 25** battle deaths and the current month records **≥ 25** battle deaths, we create an additional Resolver fact with `hazard_code=ACO` (*Armed Conflict – Onset*).
+- The same monthly battle fatality total is emitted as the escalation series (`hazard_code=ACE`). Diagnostics capture the rolling lookback, threshold, and applied configuration (`onset_rule_v1`).
+- Threshold and lookback parameters live in `resolver/ingestion/config/acled.yml` (`onset.threshold_battle_deaths` and `onset.lookback_months`) so policy changes are auditable without code edits.
+
 ## 8) Proxy Ladder (aligned to the uploaded hazard classes)
 > The exact `hazard_class` values come from `resolver/data/shocks.csv`. Use these class rules; refine per sub-type as needed.
 

--- a/resolver/tests/test_acled_monthlies.py
+++ b/resolver/tests/test_acled_monthlies.py
@@ -6,7 +6,7 @@ from resolver.ingestion import acled_client
 def _rows_to_map(rows):
     out = {}
     for row in rows:
-        key = (row["iso3"], row["metric"], row["as_of_date"])
+        key = (row["iso3"], row["hazard_code"], row["metric"], row["as_of_date"])
         out[key] = row
     return out
 
@@ -83,27 +83,29 @@ def test_acled_monthly_aggregation(monkeypatch):
 
     rows_map = _rows_to_map(rows)
 
-    kenya_conflict = rows_map[("KEN", "fatalities", "2023-01")]
-    assert kenya_conflict["value"] == 4
-    assert kenya_conflict["hazard_code"] == "ACE"
-    assert "prev12m=0" in kenya_conflict["definition_text"]
+    kenya_conflict = rows_map[("KEN", "ACE", "fatalities_battle_month", "2023-01")]
+    assert kenya_conflict["value"] == 3
+    assert "Prev12m" in kenya_conflict["definition_text"]
 
-    uganda_conflict = rows_map[("UGA", "fatalities", "2023-02")]
-    assert uganda_conflict["value"] == 35
-    assert uganda_conflict["hazard_code"] == "ACO"
-    assert "onset_prev12m=0" in uganda_conflict["method"]
+    uganda_escalation = rows_map[("UGA", "ACE", "fatalities_battle_month", "2023-02")]
+    assert uganda_escalation["value"] == 35
+    assert "battle_fatalities=35" in uganda_escalation["method"]
 
-    kenya_unrest = rows_map[("KEN", "events", "2023-01")]
+    uganda_onset = rows_map[("UGA", "ACO", "fatalities_battle_month", "2023-02")]
+    assert "onset_rule_v1" in uganda_onset["method"]
+    assert uganda_onset["value"] == 35
+
+    kenya_unrest = rows_map[("KEN", "CU", "events", "2023-01")]
     assert kenya_unrest["value"] == 2
     assert kenya_unrest["unit"] == "events"
 
-    uganda_unrest = rows_map[("UGA", "events", "2023-02")]
+    uganda_unrest = rows_map[("UGA", "CU", "events", "2023-02")]
     assert uganda_unrest["value"] == 1
 
-    kenya_participants = rows_map[("KEN", "participants", "2023-01")]
+    kenya_participants = rows_map[("KEN", "CU", "participants", "2023-01")]
     assert kenya_participants["value"] == 1700
     assert kenya_participants["unit"] == "persons"
 
-    uganda_participants = rows_map[("UGA", "participants", "2023-02")]
+    uganda_participants = rows_map[("UGA", "CU", "participants", "2023-02")]
     assert uganda_participants["value"] == 200
     assert uganda_participants["unit"] == "persons"

--- a/resolver/tests/test_acled_onset_rule_cases.py
+++ b/resolver/tests/test_acled_onset_rule_cases.py
@@ -1,0 +1,109 @@
+import pandas as pd
+import pytest
+
+from resolver.ingestion import acled_client
+
+
+@pytest.mark.parametrize(
+    "case_name,iso3,country,history,current,expected_prev12,expected_onset",
+    [
+        (
+            "positive_onset",
+            "ETH",
+            "Ethiopia",
+            [("2022-01", 6), ("2022-03", 6), ("2022-07", 6), ("2022-11", 6)],
+            ("2022-12", 25),
+            24,
+            True,
+        ),
+        (
+            "just_below_threshold",
+            "ETH",
+            "Ethiopia",
+            [("2022-02", 6), ("2022-05", 6), ("2022-08", 6), ("2022-11", 6)],
+            ("2023-01", 24),
+            24,
+            False,
+        ),
+        (
+            "no_onset_due_to_history",
+            "SDN",
+            "Sudan",
+            [("2022-02", 20), ("2022-08", 15)],
+            ("2022-12", 60),
+            35,
+            False,
+        ),
+    ],
+)
+def test_conflict_onset_rule_cases(
+    case_name,
+    iso3,
+    country,
+    history,
+    current,
+    expected_prev12,
+    expected_onset,
+):
+    current_month, current_value = current
+    all_months = history + [current]
+    df_flags = pd.DataFrame(
+        [
+            {
+                "iso3": iso3,
+                "month": month,
+                "event_type": "Battles",
+                "fatalities": value,
+            }
+            for month, value in all_months
+        ]
+    )
+
+    flags = acled_client.compute_conflict_onset_flags(df_flags)
+    target = flags[(flags["iso3"] == iso3) & (flags["month"] == current_month)]
+    assert not target.empty, f"missing onset row for {case_name}"
+    row = target.iloc[0]
+    assert row["prev12_battle_fatalities"] == expected_prev12
+    assert bool(row["is_onset"]) is expected_onset
+
+    records = [
+        {
+            "event_date": f"{month}-15",
+            "event_type": "Battles",
+            "country": country,
+            "iso3": iso3,
+            "fatalities": str(value),
+            "notes": "",
+        }
+        for month, value in all_months
+    ]
+
+    config = acled_client.load_config()
+    countries, shocks = acled_client.load_registries()
+    rows = acled_client._build_rows(
+        records,
+        config,
+        countries,
+        shocks,
+        "https://example.com/acled",
+        f"{current_month}-28",
+        f"{current_month}-28T00:00:00Z",
+    )
+
+    conflict_rows = [
+        row
+        for row in rows
+        if row["iso3"] == iso3
+        and row["metric"] == "fatalities_battle_month"
+        and row["as_of_date"] == current_month
+    ]
+    escalation = [row for row in conflict_rows if row["hazard_code"] == "ACE"]
+    assert escalation, f"expected escalation row for {case_name}"
+    assert escalation[0]["value"] == current_value
+
+    onset_rows = [row for row in conflict_rows if row["hazard_code"] == "ACO"]
+    if expected_onset:
+        assert len(onset_rows) == 1, f"expected single onset row for {case_name}"
+        assert onset_rows[0]["value"] == current_value
+    else:
+        assert not onset_rows, f"did not expect onset row for {case_name}"

--- a/resolver/tests/test_registries.py
+++ b/resolver/tests/test_registries.py
@@ -20,3 +20,11 @@ def test_shocks_registry_columns_and_scope():
     # classes must be in allowed set
     allowed = {"natural","human-induced","epidemic","other","multi"}
     assert set(s["hazard_class"]).issubset(allowed)
+
+
+def test_conflict_hazard_entries_present_without_cessation():
+    shocks = load_shocks()
+    codes = set(shocks["hazard_code"].tolist())
+    assert "ACO" in codes, "conflict onset hazard missing"
+    assert "ACE" in codes, "conflict escalation hazard missing"
+    assert not shocks["hazard_label"].str.lower().str.contains("cessation").any()


### PR DESCRIPTION
## Summary
- add a reusable helper to derive battle fatalities, rolling lookbacks, and onset flags from ACLED data
- generate dedicated conflict onset records alongside escalation rows and expose configuration plus documentation updates
- expand regression coverage for onset rule detection and guard the hazard registry against reintroducing cessation codes

## Testing
- pytest resolver/tests/test_acled_onset_rule.py resolver/tests/test_acled_onset_rule_cases.py resolver/tests/test_acled_monthlies.py resolver/tests/test_registries.py resolver/tests/test_no_conflict_cessation.py

------
https://chatgpt.com/codex/tasks/task_e_68e00c0bd5c0832c8eb504ab7e1f4d86