### PR TITLE
Harden ReliefWeb ingestion client

### DIFF
--- a/resolver/ingestion/config/reliefweb.yml
+++ b/resolver/ingestion/config/reliefweb.yml
@@ -1,12 +1,13 @@
 appname: "UNICEF-Resolver-P1L1T6"
-user_agent: "spagbot-resolver/1.0 (+https://github.com/kwyjad/Spagbot_metac-bot)"
+user_agent: "UNICEF-Resolver-P1L1T6/1.0 (+https://unicef.org/emops; contact=resolver@unicef.org)"
 base_url: "https://api.reliefweb.int/v2/reports"
 accept_header: "application/json"
-max_retries: 5
+max_retries: 6
 retry_backoff_seconds: 2
 timeout_seconds: 30
-window_days: 45
+window_days: 30
 page_size: 100
+min_page_pause_seconds: 0.6
 
 source_type_map:
   report: "sitrep"


### PR DESCRIPTION
## Summary
- update the ReliefWeb configuration to pin the UNICEF app name, user agent, and pacing/backoff defaults
- switch the ReliefWeb client to a persistent session with WAF-aware retries plus a GET fallback path
- ensure runs report the request mode and emit an empty CSV when WAF challenges persist

## Testing
- python -m compileall resolver/ingestion/reliefweb_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e0e8ddf5d8832caa7bec8208a10b29