### PR TITLE
Add manifest support for ingestion outputs

### DIFF
--- a/resolver/ingestion/_manifest.py
+++ b/resolver/ingestion/_manifest.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+def manifest_path_for(data_path: Path) -> Path:
+    """Return the manifest path for a CSV file."""
+
+    return data_path.with_suffix(f"{data_path.suffix}.meta.json")
+
+
+def compute_sha256(path: Path, chunk_size: int = 1 << 20) -> str:
+    """Compute the SHA256 hash for the given file."""
+
+    import hashlib
+
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        while True:
+            chunk = fh.read(chunk_size)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def write_csv_manifest(
+    data_path: Path,
+    *,
+    row_count: int,
+    sha256: str | None = None,
+    schema_version: str | None = None,
+    source_id: str | None = None,
+) -> Path:
+    """Write a manifest JSON file describing the CSV at ``data_path``."""
+
+    manifest_path = manifest_path_for(data_path)
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    payload: Dict[str, Any] = {
+        "format": "csv",
+        "row_count": int(row_count),
+        "data_path": data_path.name,
+        "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+    }
+    if sha256 is not None:
+        payload["sha256"] = sha256
+    if schema_version is not None:
+        payload["schema_version"] = schema_version
+    if source_id is not None:
+        payload["source_id"] = source_id
+
+    with manifest_path.open("w", encoding="utf-8") as fh:
+        json.dump(payload, fh, sort_keys=True)
+    return manifest_path
+
+
+def load_manifest(manifest_path: Path) -> Optional[Dict[str, Any]]:
+    """Load a manifest JSON file if it exists and is valid."""
+
+    try:
+        with manifest_path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except FileNotFoundError:
+        return None
+    except json.JSONDecodeError:
+        logging.getLogger(__name__).warning(
+            "Failed to parse manifest JSON", extra={"manifest_path": str(manifest_path)}
+        )
+    except OSError as exc:
+        logging.getLogger(__name__).warning(
+            "Failed to load manifest", extra={"manifest_path": str(manifest_path), "error": str(exc)}
+        )
+    return None
+
+
+def count_csv_rows(data_path: Path) -> int:
+    """Count the number of data rows (excluding header) in a CSV file."""
+
+    try:
+        with data_path.open("r", encoding="utf-8") as fh:
+            # Discard header line
+            next(fh, None)
+            return sum(1 for _ in fh)
+    except (FileNotFoundError, OSError, UnicodeDecodeError):
+        return 0
+
+
+def ensure_manifest_for_csv(
+    data_path: Path,
+    *,
+    schema_version: str | None = None,
+    source_id: str | None = None,
+) -> Dict[str, Any]:
+    """Ensure a manifest exists and is up to date for the CSV at ``data_path``."""
+
+    row_count = count_csv_rows(data_path)
+    sha256 = compute_sha256(data_path)
+    manifest_path = write_csv_manifest(
+        data_path,
+        row_count=row_count,
+        sha256=sha256,
+        schema_version=schema_version,
+        source_id=source_id,
+    )
+    manifest = load_manifest(manifest_path)
+    return manifest or {
+        "format": "csv",
+        "row_count": row_count,
+        "data_path": data_path.name,
+        "sha256": sha256,
+    }

--- a/resolver/ingestion/acled_client.py
+++ b/resolver/ingestion/acled_client.py
@@ -17,6 +17,7 @@ import yaml
 from urllib.parse import urlencode
 
 from .acled_auth import get_auth_header
+from resolver.ingestion._manifest import ensure_manifest_for_csv
 
 ROOT = Path(__file__).resolve().parents[1]
 DATA = ROOT / "data"
@@ -830,6 +831,7 @@ def _write_header_only(path: Path) -> None:
     with path.open("w", newline="", encoding="utf-8") as fp:
         writer = csv.writer(fp)
         writer.writerow(CANONICAL_HEADERS)
+    ensure_manifest_for_csv(path)
 
 
 def _write_rows(rows: Sequence[MutableMapping[str, Any]], path: Path) -> None:
@@ -839,6 +841,7 @@ def _write_rows(rows: Sequence[MutableMapping[str, Any]], path: Path) -> None:
         writer.writeheader()
         for row in rows:
             writer.writerow(row)
+    ensure_manifest_for_csv(path)
 
 
 def main() -> bool:

--- a/resolver/ingestion/dtm_client.py
+++ b/resolver/ingestion/dtm_client.py
@@ -13,6 +13,8 @@ from typing import Any, Dict, Iterable, List, MutableMapping, Optional, Sequence
 import pandas as pd
 import yaml
 
+from resolver.ingestion._manifest import ensure_manifest_for_csv
+
 ROOT = Path(__file__).resolve().parents[1]
 DATA = ROOT / "data"
 STAGING = ROOT / "staging"
@@ -342,6 +344,7 @@ def build_event_id(
 def _write_header_only(path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     pd.DataFrame(columns=CANONICAL_HEADERS).to_csv(path, index=False)
+    ensure_manifest_for_csv(path)
 
 
 def _write_rows(rows: Sequence[Dict[str, Any]], *, path: Path) -> None:
@@ -359,6 +362,7 @@ def _write_rows(rows: Sequence[Dict[str, Any]], *, path: Path) -> None:
     df = df[CANONICAL_HEADERS]
     path.parent.mkdir(parents=True, exist_ok=True)
     df.to_csv(path, index=False)
+    ensure_manifest_for_csv(path)
 
 
 def collect_rows() -> List[Dict[str, Any]]:

--- a/resolver/ingestion/ipc_client.py
+++ b/resolver/ingestion/ipc_client.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, Iterable, List, MutableMapping, Optional, Sequence
 import pandas as pd
 import yaml
 
+from resolver.ingestion._manifest import ensure_manifest_for_csv
 from resolver.tools.denominators import get_population_record, safe_pct_to_people
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -720,6 +721,7 @@ def _write_rows(rows: Sequence[Dict[str, Any]], *, path: Path) -> None:
         df = df[CANONICAL_HEADERS]
     path.parent.mkdir(parents=True, exist_ok=True)
     df.to_csv(path, index=False)
+    ensure_manifest_for_csv(path)
 
 
 def _write_header_only(path: Path) -> None:

--- a/resolver/ingestion/run_all_stubs.py
+++ b/resolver/ingestion/run_all_stubs.py
@@ -24,6 +24,12 @@ if str(PROJECT_ROOT) not in sys.path:
 
 import yaml
 
+from resolver.ingestion._manifest import (
+    count_csv_rows,
+    ensure_manifest_for_csv,
+    load_manifest,
+    manifest_path_for,
+)
 from resolver.ingestion._retry import retry_call
 from resolver.ingestion._runner_logging import (
     attach_connector_handler,
@@ -293,16 +299,38 @@ def _load_yaml(path: Optional[Path]) -> dict:
     return data if isinstance(data, dict) else {}
 
 
-def _count_rows(path: Optional[Path]) -> int:
-    if not path or not path.exists():
-        return 0
-    try:
-        with path.open("r", encoding="utf-8", newline="") as handle:
-            reader = csv.reader(handle)
-            next(reader, None)
-            return sum(1 for _ in reader)
-    except Exception:
-        return 0
+def _rows_and_method(path: Optional[Path]) -> tuple[int, str]:
+    if path is None or not path.exists():
+        return 0, "missing"
+
+    manifest = load_manifest(manifest_path_for(path))
+    manifest_rows: Optional[int]
+    if manifest and isinstance(manifest.get("row_count"), int):
+        manifest_rows = int(manifest["row_count"])
+    else:
+        manifest_rows = None
+
+    rows_actual = count_csv_rows(path)
+    if manifest_rows is None:
+        return rows_actual, "recount"
+
+    if rows_actual != manifest_rows:
+        logging.getLogger(__name__).warning(
+            "Manifest row_count mismatch; recounting",
+            extra={
+                "event": "manifest_mismatch",
+                "path": redact(str(path)),
+                "manifest_rows": manifest_rows,
+                "recount_rows": rows_actual,
+            },
+        )
+        try:
+            ensure_manifest_for_csv(path)
+        except FileNotFoundError:
+            pass
+        return rows_actual, "manifest+verified"
+
+    return manifest_rows, "manifest"
 
 
 def _summarise_connector(name: str) -> str | None:
@@ -310,8 +338,10 @@ def _summarise_connector(name: str) -> str | None:
     if not meta:
         return None
     label = meta["label"]
-    rows = _count_rows(meta["staging"])
+    rows, method = _rows_and_method(meta["staging"])
     parts = [f"[{label}] rows:{rows}"]
+    if method in {"recount", "manifest+verified"}:
+        parts.append(f"rows_method:{method}")
     cfg = _load_yaml(meta.get("config"))
 
     if name == "who_phe_client.py":
@@ -521,9 +551,9 @@ def _rows_written(before: int, after: int) -> int:
 
 def _run_connector(spec: ConnectorSpec, logger: logging.LoggerAdapter) -> Dict[str, object]:
     start = time.perf_counter()
-    rows_before = _count_rows(spec.output_path)
+    rows_before, method_before = _rows_and_method(spec.output_path)
     _invoke_connector(spec.path, logger=logger)
-    rows_after = _count_rows(spec.output_path)
+    rows_after, method_after = _rows_and_method(spec.output_path)
     duration_ms = int((time.perf_counter() - start) * 1000)
     logger.info(
         "completed",
@@ -532,9 +562,17 @@ def _run_connector(spec: ConnectorSpec, logger: logging.LoggerAdapter) -> Dict[s
             "duration_ms": duration_ms,
             "rows_written": _rows_written(rows_before, rows_after),
             "rows_total": rows_after,
+            "rows_method_before": method_before,
+            "rows_method_after": method_after,
         },
     )
-    return {"status": "ok", "rows": rows_after, "duration_ms": duration_ms}
+    return {
+        "status": "ok",
+        "rows": rows_after,
+        "duration_ms": duration_ms,
+        "rows_method": method_after,
+        "rows_method_before": method_before,
+    }
 
 
 def _parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
@@ -700,6 +738,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         rows = 0
         status = "skipped"
         notes: Optional[str] = None
+        result: Dict[str, object] = {}
         connector_start = time.perf_counter()
         try:
             if spec.skip_reason:
@@ -762,12 +801,16 @@ def main(argv: Optional[List[str]] = None) -> int:
                 is_retryable=_should_retry,
             )
             rows = int(result.get("rows", 0))
+            rows_method = str(result.get("rows_method") or "")
             duration_ms = int((time.perf_counter() - connector_start) * 1000)
             if spec.output_path and spec.output_path.exists() and rows == 0:
                 status = "ok-empty"
                 notes = "header-only"
             else:
                 status = "ok"
+            if rows_method in {"recount", "manifest+verified"}:
+                method_note = f"rows:{rows_method}"
+                notes = f"{notes}; {method_note}" if notes else method_note
             child.info(
                 "finished",
                 extra={
@@ -776,6 +819,7 @@ def main(argv: Optional[List[str]] = None) -> int:
                     "rows": rows,
                     "attempts": attempts,
                     "duration_ms": duration_ms,
+                    "rows_method": rows_method or None,
                     "notes": redact(notes) if notes else None,
                 },
             )
@@ -807,6 +851,7 @@ def main(argv: Optional[List[str]] = None) -> int:
                     "duration_ms": int((time.perf_counter() - connector_start) * 1000),
                     "notes": redact(notes) if notes else None,
                     "kind": spec.kind,
+                    "rows_method": result.get("rows_method") if result else None,
                 }
             )
 

--- a/resolver/ingestion/tests/test_manifests.py
+++ b/resolver/ingestion/tests/test_manifests.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from resolver.ingestion._manifest import (
+    count_csv_rows,
+    ensure_manifest_for_csv,
+    load_manifest,
+    manifest_path_for,
+)
+
+
+def test_manifest_creation_and_repair(tmp_path: Path) -> None:
+    csv_path = tmp_path / "example.csv"
+    csv_path.write_text("a,b\n", encoding="utf-8")
+
+    manifest = ensure_manifest_for_csv(csv_path)
+    manifest_path = manifest_path_for(csv_path)
+
+    assert manifest_path.exists(), "manifest file should be created"
+    assert manifest["format"] == "csv"
+    assert manifest["row_count"] == 0
+    assert manifest["data_path"] == csv_path.name
+    assert "sha256" in manifest
+    assert "generated_at" in manifest
+
+    csv_path.write_text("a,b\n1,2\n3,4\n5,6\n", encoding="utf-8")
+    updated = ensure_manifest_for_csv(csv_path)
+
+    assert updated["row_count"] == 3
+    assert updated.get("sha256") != manifest.get("sha256")
+
+    corrupt = load_manifest(manifest_path) or {}
+    corrupt["row_count"] = 999
+    manifest_path.write_text(json.dumps(corrupt), encoding="utf-8")
+
+    recount = count_csv_rows(csv_path)
+    reloaded = load_manifest(manifest_path)
+    assert reloaded is not None
+    assert reloaded["row_count"] != recount
+
+    repaired = ensure_manifest_for_csv(csv_path)
+    assert repaired["row_count"] == recount
+    fixed = load_manifest(manifest_path)
+    assert fixed is not None
+    assert fixed["row_count"] == recount

--- a/resolver/ingestion/unhcr_client.py
+++ b/resolver/ingestion/unhcr_client.py
@@ -25,6 +25,8 @@ import requests
 import pandas as pd
 import yaml
 
+from resolver.ingestion._manifest import ensure_manifest_for_csv
+
 ROOT = Path(__file__).resolve().parents[1]
 DATA = ROOT / "data"
 STAGING = ROOT / "staging"
@@ -331,10 +333,12 @@ def main():
 
     if not rows:
         pd.DataFrame(columns=COLUMNS).to_csv(out, index=False)
+        ensure_manifest_for_csv(out)
         print(f"wrote empty {out}")
         return
 
     pd.DataFrame(rows, columns=COLUMNS).to_csv(out, index=False)
+    ensure_manifest_for_csv(out)
     print(f"wrote {out} rows={len(rows)}")
 
 if __name__ == "__main__":

--- a/resolver/ingestion/unhcr_odp_client.py
+++ b/resolver/ingestion/unhcr_odp_client.py
@@ -19,6 +19,8 @@ from urllib.parse import parse_qs, urlencode, urljoin, urlparse
 
 import requests
 
+from resolver.ingestion._manifest import ensure_manifest_for_csv
+
 ROOT = Path(__file__).resolve().parents[1]
 DATA = ROOT / "data"
 STAGING = ROOT / "staging"
@@ -440,6 +442,7 @@ def write_rows(rows: Iterable[Dict[str, str]]) -> None:
         writer.writeheader()
         for row in rows:
             writer.writerow({key: row.get(key, "") for key in CANONICAL_HEADER})
+    ensure_manifest_for_csv(OUT_PATH)
 
 
 def main() -> int:

--- a/resolver/ingestion/wfp_mvam_client.py
+++ b/resolver/ingestion/wfp_mvam_client.py
@@ -16,6 +16,7 @@ import pandas as pd
 import requests
 import yaml
 
+from resolver.ingestion._manifest import ensure_manifest_for_csv
 from resolver.tools.denominators import (
     get_population_record,
     safe_pct_to_people,
@@ -322,12 +323,14 @@ def load_shocks() -> pd.DataFrame:
 def _write_header_only(path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     pd.DataFrame(columns=CANONICAL_HEADERS).to_csv(path, index=False)
+    ensure_manifest_for_csv(path)
 
 
 def _write_rows(rows: List[List[Any]], path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     df = pd.DataFrame(rows, columns=CANONICAL_HEADERS)
     df.to_csv(path, index=False)
+    ensure_manifest_for_csv(path)
 
 
 def _maybe_apply_hxl(df: pd.DataFrame) -> pd.DataFrame:

--- a/resolver/ingestion/who_phe_client.py
+++ b/resolver/ingestion/who_phe_client.py
@@ -17,6 +17,8 @@ import pandas as pd
 import requests
 import yaml
 
+from resolver.ingestion._manifest import ensure_manifest_for_csv
+
 ROOT = Path(__file__).resolve().parents[1]
 DATA = ROOT / "data"
 STAGING = ROOT / "staging"
@@ -538,6 +540,7 @@ def build_event_id(
 def _write_header_only(path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     pd.DataFrame(columns=CANONICAL_HEADERS).to_csv(path, index=False)
+    ensure_manifest_for_csv(path)
 
 
 def _write_rows(rows: Sequence[Dict[str, Any]], *, path: Path) -> None:
@@ -551,6 +554,7 @@ def _write_rows(rows: Sequence[Dict[str, Any]], *, path: Path) -> None:
     df = df[CANONICAL_HEADERS]
     path.parent.mkdir(parents=True, exist_ok=True)
     df.to_csv(path, index=False)
+    ensure_manifest_for_csv(path)
 
 
 def collect_rows() -> List[Dict[str, Any]]:


### PR DESCRIPTION
## Summary
- add a reusable manifest helper to capture row counts and hashes for staging CSVs
- update ingestion connectors and the runner to emit, consume, and verify manifests when summarising row counts
- add unit tests that exercise manifest creation, updates, and mismatch repair

## Testing
- pytest resolver/ingestion/tests/test_manifests.py -q


------
https://chatgpt.com/codex/tasks/task_e_68e0eb450254832c920ae8fccf6043bf