### PR TITLE
Add shared ingestion utilities and upgrade hazard connectors

### DIFF
--- a/resolver/ingestion/config/dtm.yml
+++ b/resolver/ingestion/config/dtm.yml
@@ -1,26 +1,10 @@
-base_url: https://data.humdata.org
-package_query_terms: ["IOM DTM", "Displacement Tracking Matrix", "DTM"]
-prefer_hxl: true
-max_datasets: 400
-monthly_first: true
-
-shock_keywords:
-  flood: ["flood", "inundation", "inondation"]
-  drought: ["drought", "aridity"]
-  tropical_cyclone: ["cyclone", "typhoon", "hurricane", "tc"]
-  heat_wave: ["heat wave", "heatwave", "extreme heat"]
-  armed_conflict_onset: ["conflict onset", "outbreak of conflict"]
-  armed_conflict_escalation: ["escalation", "clashes", "intensification"]
-  civil_unrest: ["protest", "unrest", "riots"]
-  displacement_influx: ["arrivals", "influx", "flow monitoring", "fmp", "ett", "mt"]
-  economic_crisis: ["economic crisis", "inflation", "currency"]
-  phe: ["outbreak", "epidemic", "pandemic", "cholera", "measles", "covid"]
-
-series_hints:
-  fmp: incident
-  ett: incident
-  mt: incident
-  idp_stock: cumulative
-
-allow_first_month_delta: false
-default_hazard: displacement_influx
+enabled: false
+sources:
+  - type: file
+    id_or_path: ""
+stock_to_flow_rule: diff_nonneg
+admin_agg: both
+cause_map:
+  conflict: conflict
+  disaster: disaster
+country_aliases: {}

--- a/resolver/ingestion/config/emdat.yml
+++ b/resolver/ingestion/config/emdat.yml
@@ -1,27 +1,13 @@
-sources:
-  - name: emdat_events
-    kind: csv
-    url: https://data.humdata.org/dataset/emdat-example.csv
-    country_keys: ["ISO", "iso3", "#country+code", "Country ISO3", "Country"]
-    start_date_keys: ["Start Date", "Start", "Began", "#date+start"]
-    end_date_keys: ["End Date", "End", "Finished", "#date+end"]
-    type_keys: ["Disaster Type", "Type"]
-    subtype_keys: ["Disaster Subtype", "Subtype"]
-    total_affected_keys: ["Total Affected", "#affected+total", "Affected Total"]
-    affected_keys: ["Affected", "#affected"]
-    injured_keys: ["Injured", "#affected+injured"]
-    homeless_keys: ["Homeless", "#affected+homeless"]
-    id_keys: ["Dis No", "Event ID", "EMDAT ID"]
-    title_keys: ["Event Name", "Title"]
-    publisher: "CRED/EM-DAT"
-    source_type: "other"
-prefer_hxl: true
-allocation_policy: prorata
-shock_map:
-  flood: ["Flood"]
-  drought: ["Drought"]
-  tropical_cyclone: ["Storm", "Tropical cyclone", "Hurricane", "Typhoon"]
-  heat_wave: ["Heat wave", "Extreme temperature", "Heat"]
-  phe: ["Epidemic", "Infectious disease", "Outbreak"]
-  other: ["Industrial accident", "Technological", "Transport"]
-default_hazard: other
+enabled: false
+source:
+  type: file
+  path: ""
+allocation:
+  multi_month: linear
+value_types:
+  - affected
+  - deaths
+  - injured
+  - homeless
+hazard_map: {}
+country_aliases: {}

--- a/resolver/ingestion/config/gdacs.yml
+++ b/resolver/ingestion/config/gdacs.yml
@@ -1,32 +1,19 @@
-base_urls:
-  # Provide concrete endpoints/feeds here; support list in case multiple are needed
-  event_list: "<GDACS event-list endpoint with from/to params>"
-  event_details: "<GDACS event-details endpoint with event_id & episode_id>"
-
-window_days: 60
-prefer_hxl: false
-
-keys:
-  id: ["event_id","id"]
-  episode: ["episode_id","episode"]
-  type: ["event_type","type","hazard"]
-  start: ["start_date","fromdate","begindate"]
-  end:   ["end_date","todate","enddate"]
-  iso3:  ["iso3","country_iso3","iso"]
-  country: ["country","country_name"]
-  impact: ["population","population_exposed","affected","total_affected"]
-  title: ["title","name"]
-  updated: ["updated","last_update","report_time"]
-  url: ["url","detail_url","link"]
-
+enabled: false
+window_days: 365
+retry:
+  tries: 5
+  backoff: 2
+endpoints:
+  event_list: "https://www.gdacs.org/gdacsapi/api/events/geteventlist"
+  event_details: "https://www.gdacs.org/gdacsapi/api/events/getevent"
 hazard_map:
-  earthquake: ["EQ","Earthquake"]
-  tropical_cyclone: ["TC","ST","CY","Tropical Cyclone","Storm"]
-  flood: ["FL","Flood"]
-  volcano: ["VO","Volcano"]
-default_hazard: "other"
-
-allocation_policy: "prorata"   # prorata | start
-dedup_strategy: "max"          # max | sum
-source_type: "other"
-publisher: "GDACS"
+  EQ: earthquake
+  FL: flood
+  TC: tropical_cyclone
+  VO: volcano
+  WF: wildfire
+severity_map:
+  Green: 0
+  Orange: 1
+  Red: 2
+country_aliases: {}

--- a/resolver/ingestion/config/worldpop.yml
+++ b/resolver/ingestion/config/worldpop.yml
@@ -1,12 +1,15 @@
-product: un_adj_unconstrained
-years_back: 0
-prefer_hxl: false
-keys:
-  iso3: ["iso3", "country_code", "country_iso3", "#country+code"]
-  year: ["year", "#date+year"]
-  population: ["population", "pop_total", "#population"]
-  notes: ["notes", "comment", "#meta+notes"]
-source:
-  publisher: "WorldPop"
-  source_type: "official"
-  url_template: "https://example.org/worldpop/{product}_{year}.csv"
+enabled: true
+product: unadj_national_totals
+years:
+  - 2015
+  - 2016
+  - 2017
+  - 2018
+  - 2019
+  - 2020
+  - 2021
+  - 2022
+  - 2023
+  - 2024
+  - 2025
+country_aliases: {}

--- a/resolver/ingestion/gdacs_client.py
+++ b/resolver/ingestion/gdacs_client.py
@@ -1,784 +1,324 @@
 #!/usr/bin/env python3
-"""GDACS connector that converts alerts into monthly incident PA rows."""
+"""GDACS connector that emits monthly hazard signals."""
 
 from __future__ import annotations
 
 import csv
-import hashlib
-import os
-from dataclasses import dataclass
-from datetime import date, datetime, timedelta
+import json
+import logging
+import time
+from datetime import date, timedelta
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, MutableMapping, Optional, Sequence, Tuple
-from urllib.parse import urlparse
+from typing import Any, Dict, Iterable, List, Mapping, Optional
 
-import pandas as pd
 import requests
 import yaml
 
+from resolver.ingestion._manifest import ensure_manifest_for_csv
+from resolver.ingestion.utils import map_hazard, month_start, parse_date, stable_digest, to_iso3
+
 ROOT = Path(__file__).resolve().parents[1]
-DATA = ROOT / "data"
 STAGING = ROOT / "staging"
-CONFIG = ROOT / "ingestion" / "config" / "gdacs.yml"
+CONFIG_PATH = ROOT / "ingestion" / "config" / "gdacs.yml"
+OUTPUT_PATH = STAGING / "gdacs_signals.csv"
 
-COUNTRIES = DATA / "countries.csv"
+LOG = logging.getLogger("resolver.ingestion.gdacs")
 
-OUT_DIR = STAGING
-OUT_PATH = OUT_DIR / "gdacs.csv"
-
-CANONICAL_HEADERS = [
+COLUMNS = [
+    "source",
+    "hazard_type",
+    "country_iso3",
     "event_id",
-    "country_name",
-    "iso3",
-    "hazard_code",
-    "hazard_label",
-    "hazard_class",
-    "metric",
-    "series_semantics",
+    "as_of",
+    "month_start",
+    "value_type",
     "value",
     "unit",
-    "as_of_date",
-    "publication_date",
-    "publisher",
-    "source_type",
-    "source_url",
-    "doc_title",
-    "definition_text",
     "method",
     "confidence",
-    "revision",
-    "ingested_at",
+    "raw_event_id",
+    "raw_fields_json",
 ]
 
-SERIES_SEMANTICS = "incident"
-UNIT = "persons"
-METRIC = "affected"
-
-DEFAULT_METHOD = (
-    "GDACS alerts; monthly-first; event→month allocation; "
-    "dedup=episode-aware; policy={policy}"
-)
-
-DEFAULT_DEFINITION = (
-    "Population from GDACS alerts using fields {fields}; monthly allocation policy={policy}; "
-    "per-event dedup strategy={strategy}."
-)
-
-DEBUG = os.getenv("RESOLVER_DEBUG", "0") == "1"
-
-
-@dataclass(frozen=True)
-class Hazard:
-    code: str
-    label: str
-    hazard_class: str
-
-
-HAZARD_METADATA = {
-    "earthquake": Hazard("earthquake", "Earthquake", "geophysical"),
-    "tropical_cyclone": Hazard("tropical_cyclone", "Tropical Cyclone", "meteorological"),
-    "flood": Hazard("flood", "Flood", "hydrological"),
-    "volcano": Hazard("volcano", "Volcanic Activity", "volcanic"),
-    "other": Hazard("other", "Other", "other"),
+DEFAULT_ENDPOINTS = {
+    "event_list": "https://www.gdacs.org/gdacsapi/api/events/geteventlist",
+    "event_details": "https://www.gdacs.org/gdacsapi/api/events/getevent",
 }
+DEFAULT_SEVERITY = {"green": 0, "orange": 1, "red": 2}
+
+USER_AGENT = "UNICEF-Resolver-P1L1T6"
 
 
-def dbg(message: str) -> None:
-    if DEBUG:
-        print(f"[gdacs] {message}")
-
-
-def _is_placeholder_url(value: Any) -> bool:
-    text = str(value or "").strip()
-    if not text:
-        return True
-    lowered = text.lower()
-    if "<" in text or ">" in text:
-        return True
-    if "event-list endpoint" in lowered or "event_list endpoint" in lowered:
-        return True
-    if "event-details endpoint" in lowered or "event_details endpoint" in lowered:
-        return True
-    if "placeholder" in lowered:
-        return True
-    parsed = urlparse(text)
-    if not parsed.scheme or parsed.scheme not in {"http", "https"}:
-        return True
-    if not parsed.netloc:
-        return True
-    return False
-
-
-def _env_bool(name: str, default: bool) -> bool:
-    value = os.getenv(name)
-    if value is None:
-        return default
-    return value.strip().lower() in {"1", "true", "yes", "y", "on"}
-
-
-def _env_int(name: str) -> Optional[int]:
-    value = os.getenv(name)
-    if value is None:
-        return None
-    try:
-        return int(value)
-    except ValueError:
-        return None
-
-
-def _config_invalid_reason(cfg: Dict[str, Any]) -> Optional[str]:
-    base_urls = cfg.get("base_urls") or {}
-    event_list_url = base_urls.get("event_list")
-    if _is_placeholder_url(event_list_url):
-        return "event_list endpoint"
-    details_url = base_urls.get("event_details")
-    if details_url and _is_placeholder_url(details_url):
-        return "event_details endpoint"
-    return None
-
-
-def load_config() -> Dict[str, Any]:
-    if not CONFIG.exists():
+def load_config() -> dict[str, Any]:
+    if not CONFIG_PATH.exists():
         return {}
-    with open(CONFIG, "r", encoding="utf-8") as fp:
-        cfg = yaml.safe_load(fp) or {}
-    return cfg
+    with CONFIG_PATH.open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle) or {}
 
 
-def load_countries() -> Tuple[Dict[str, str], Dict[str, str]]:
-    df = pd.read_csv(COUNTRIES, dtype=str).fillna("")
-    iso_to_name: Dict[str, str] = {}
-    name_to_iso: Dict[str, str] = {}
-    for row in df.itertuples(index=False):
-        iso = str(row.iso3).strip().upper()
-        name = str(row.country_name).strip()
-        if not iso:
-            continue
-        iso_to_name[iso] = name
-        key = _normalise_text(name)
-        if key:
-            name_to_iso[key] = iso
-    return iso_to_name, name_to_iso
+def ensure_header_only() -> None:
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with OUTPUT_PATH.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(COLUMNS)
+    ensure_manifest_for_csv(OUTPUT_PATH, schema_version="gdacs_signals.v1", source_id="gdacs")
 
 
-def _normalise_text(value: Any) -> str:
-    return "".join(ch for ch in str(value or "").strip().lower() if ch.isalnum())
-
-
-def _pick(mapping: MutableMapping[str, Any], keys: Sequence[str]) -> Optional[Any]:
-    for key in keys:
-        if key in mapping:
-            val = mapping.get(key)
-            if val not in (None, ""):
-                return val
-    return None
-
-
-def _coerce_to_list(value: Any) -> List[str]:
-    if value is None:
-        return []
-    if isinstance(value, (list, tuple, set)):
-        return [str(item).strip() for item in value if str(item).strip()]
-    text = str(value).strip()
-    if not text:
-        return []
-    if "," in text:
-        return [part.strip() for part in text.split(",") if part.strip()]
-    return [text]
-
-
-def hazard_from_key(key: str) -> Hazard:
-    key_norm = str(key or "").strip().lower()
-    return HAZARD_METADATA.get(key_norm, HAZARD_METADATA["other"])
-
-
-def map_hazard(raw: Any, hazard_map: Dict[str, Sequence[str]], default_key: str) -> Hazard:
-    text = str(raw or "").strip()
-    if not text:
-        return hazard_from_key(default_key)
-    norm = _normalise_text(text)
-    for canonical, candidates in hazard_map.items():
-        for cand in candidates or []:
-            if norm == _normalise_text(cand):
-                return hazard_from_key(canonical)
-    return hazard_from_key(default_key)
-
-
-def _parse_datetime(value: Any) -> Optional[datetime]:
-    if value is None:
-        return None
-    text = str(value).strip()
-    if not text:
-        return None
-    text = text.replace("Z", "+00:00")
-    for fmt in ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S"):
-        try:
-            if fmt.endswith("%z"):
-                return datetime.strptime(text, fmt)
-            return datetime.strptime(text, fmt)
-        except ValueError:
-            continue
-    try:
-        return datetime.fromisoformat(text)
-    except ValueError:
-        return None
-
-
-def _ensure_date(value: Any) -> Optional[date]:
-    if isinstance(value, datetime):
-        return value.date()
-    if isinstance(value, date):
-        return value
-    parsed = _parse_datetime(value)
-    if parsed:
-        return parsed.date()
-    return None
-
-
-def _parse_float(value: Any) -> Optional[float]:
-    if value is None:
-        return None
-    text = str(value).strip()
-    if not text:
-        return None
-    cleaned = text.replace(",", "")
-    try:
-        return float(cleaned)
-    except ValueError:
-        return None
-
-
-def _month_key(day: date) -> str:
-    return day.strftime("%Y-%m")
-
-
-def _month_end(day: date) -> date:
-    next_month = (day.replace(day=28) + timedelta(days=4)).replace(day=1)
-    return next_month - timedelta(days=1)
-
-
-def _inclusive_days(start: date, end: date) -> int:
-    return (end - start).days + 1
-
-
-def month_segments(start: date, end: date) -> List[Tuple[str, int]]:
-    if end < start:
-        end = start
-    segments: List[Tuple[str, int]] = []
-    cursor = start
-    while cursor <= end:
-        segment_end = min(_month_end(cursor), end)
-        month = _month_key(cursor)
-        days = _inclusive_days(cursor, segment_end)
-        segments.append((month, days))
-        cursor = segment_end + timedelta(days=1)
-    return segments
-
-
-def allocate_value(total: int, start: date, end: date, policy: str) -> Dict[str, int]:
-    policy_norm = (policy or "prorata").strip().lower()
-    if total <= 0:
-        return {}
-    if end < start:
-        end = start
-    if policy_norm == "start":
-        return {_month_key(start): int(round(total))}
-
-    segments = month_segments(start, end)
-    total_days = sum(days for _, days in segments)
-    if total_days <= 0:
-        return {_month_key(start): int(round(total))}
-
-    allocations: Dict[str, int] = {month: 0 for month, _ in segments}
-    remainders: List[Tuple[int, str]] = []
-    assigned = 0
-    for month, days in segments:
-        raw = total * days
-        base = raw // total_days
-        remainder = raw % total_days
-        allocations[month] += int(base)
-        assigned += int(base)
-        remainders.append((int(remainder), month))
-
-    remaining = int(round(total)) - assigned
-    for remainder, month in sorted(remainders, reverse=True):
-        if remaining <= 0:
-            break
-        allocations[month] += 1
-        remaining -= 1
-
-    if remaining != 0:
-        # Adjust final bucket to ensure totals match (guard against rounding drift)
-        last_month = segments[-1][0]
-        allocations[last_month] += remaining
-
-    return {month: max(0, value) for month, value in allocations.items() if value > 0}
-
-
-def allocate_event(event: "GDACSEvent", policy: str) -> Dict[str, int]:
-    return allocate_value(event.impact_value, event.start_date, event.end_date, policy)
-
-
-@dataclass
-class GDACSEvent:
-    event_id: str
-    episode_id: str
-    iso3: str
-    hazard: Hazard
-    start_date: date
-    end_date: date
-    impact_value: int
-    source_url: str
-    doc_title: str
-    publication_date: Optional[date]
-    impact_field: str
-
-
-def _write_header_only(path: Path) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w", newline="", encoding="utf-8") as fp:
-        writer = csv.writer(fp)
-        writer.writerow(CANONICAL_HEADERS)
-
-
-def _digest(parts: Iterable[Any]) -> str:
-    text = "|".join(str(part or "") for part in parts)
-    return hashlib.sha1(text.encode("utf-8")).hexdigest()[:12]
-
-
-def _prepare_session() -> requests.Session:
+def _create_session() -> requests.Session:
     session = requests.Session()
-    appname = os.getenv("RELIEFWEB_APPNAME", "Resolver-GDACS-Client/1.0")
-    session.headers.update({"User-Agent": appname})
+    session.headers.update({"User-Agent": USER_AGENT})
     return session
 
 
-def _read_response_json(data: Any) -> List[MutableMapping[str, Any]]:
-    if data is None:
-        return []
-    if isinstance(data, list):
-        return [dict(item) if isinstance(item, MutableMapping) else {} for item in data]
-    if isinstance(data, MutableMapping):
-        for key in ("events", "data", "results", "items"):
-            if key in data and isinstance(data[key], list):
-                return [dict(item) if isinstance(item, MutableMapping) else {} for item in data[key]]
-        return [dict(data)]
+def _as_list(payload: Any) -> List[Dict[str, Any]]:
+    if isinstance(payload, list):
+        return [item if isinstance(item, dict) else {} for item in payload]
+    if isinstance(payload, dict):
+        for key in ("events", "data", "results", "features", "items"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return [item if isinstance(item, dict) else {} for item in value]
+        return [payload]
     return []
 
 
-def _fetch_event_list(session: requests.Session, cfg: Dict[str, Any], start: date, end: date) -> List[MutableMapping[str, Any]]:
-    base = (cfg.get("base_urls") or {}).get("event_list")
-    if not base:
-        raise RuntimeError("GDACS event_list base URL missing in config")
-    params = {"from": start.isoformat(), "to": end.isoformat()}
-    try:
-        response = session.get(base, params=params, timeout=60)
-        response.raise_for_status()
-        data = response.json()
-    except requests.RequestException as exc:
-        raise RuntimeError(f"GDACS event list request failed: {exc}") from exc
-    except ValueError as exc:  # pragma: no cover - JSON decode errors
-        raise RuntimeError("GDACS event list did not return JSON") from exc
-    return _read_response_json(data)
+def _ci_get(mapping: Mapping[str, Any], key: str) -> Any:
+    lower = key.lower()
+    for actual_key, value in mapping.items():
+        if actual_key.lower() == lower:
+            return value
+    return None
 
 
-def _fetch_event_details(
-    session: requests.Session,
-    cfg: Dict[str, Any],
-    event: MutableMapping[str, Any],
-    keys: Dict[str, Sequence[str]],
-) -> MutableMapping[str, Any]:
-    details_url = (cfg.get("base_urls") or {}).get("event_details")
-    if not details_url:
-        return event
-    event_id = _pick(event, keys.get("id", []))
-    if not event_id:
-        return event
-    params: Dict[str, Any] = {"eventid": event_id}
-    episode_id = _pick(event, keys.get("episode", []))
-    if episode_id:
-        params["episodeid"] = episode_id
-    try:
-        response = session.get(details_url, params=params, timeout=60)
-        response.raise_for_status()
-        payload = response.json()
-    except requests.RequestException:
-        return event
-    except ValueError:  # pragma: no cover - JSON decode errors
-        return event
-    details_list = _read_response_json(payload)
-    if not details_list:
-        return event
-    merged = dict(event)
-    merged.update(details_list[0])
-    return merged
+def _pluck(record: Mapping[str, Any], *candidates: str) -> Any:
+    for key in candidates:
+        if key in record:
+            value = record.get(key)
+            if value not in (None, ""):
+                return value
+        if "properties" in record and isinstance(record["properties"], Mapping):
+            nested = _pluck(record["properties"], key)
+            if nested not in (None, ""):
+                return nested
+        lowered = key.lower()
+        for actual, value in record.items():
+            if actual.lower() == lowered and value not in (None, ""):
+                return value
+    return None
 
 
-def _resolve_iso3(
-    event: MutableMapping[str, Any],
-    keys: Dict[str, Sequence[str]],
-    name_to_iso: Dict[str, str],
-) -> List[str]:
-    iso_candidates: List[str] = []
-    seen: set[str] = set()
-
-    iso_raw = _pick(event, keys.get("iso3", []))
-    for value in _coerce_to_list(iso_raw):
-        iso = value.upper()
-        if len(iso) == 3 and iso not in seen:
-            iso_candidates.append(iso)
-            seen.add(iso)
-
-    if iso_candidates:
-        return iso_candidates
-
-    country_val = _pick(event, keys.get("country", []))
-    for name in _coerce_to_list(country_val):
-        iso = name_to_iso.get(_normalise_text(name))
-        if iso and iso not in seen:
-            iso_candidates.append(iso)
-            seen.add(iso)
-
-    return iso_candidates
+def _extract_countries(event: Mapping[str, Any]) -> List[Mapping[str, Any]]:
+    countries: List[Mapping[str, Any]] = []
+    candidate = _pluck(event, "countries", "country", "countrylist")
+    if isinstance(candidate, list):
+        for item in candidate:
+            if isinstance(item, Mapping):
+                countries.append(item)
+            elif isinstance(item, str):
+                countries.append({"name": item})
+    elif isinstance(candidate, Mapping):
+        countries.append(candidate)
+    elif isinstance(candidate, str):
+        for part in candidate.replace(";", ",").split(","):
+            part = part.strip()
+            if part:
+                countries.append({"name": part})
+    else:
+        iso = _pluck(event, "countryiso", "iso3", "iso")
+        name = _pluck(event, "countryname")
+        if iso or name:
+            countries.append({"iso3": iso, "name": name})
+    return countries
 
 
-def _extract_publication_date(event: MutableMapping[str, Any], keys: Dict[str, Sequence[str]]) -> Optional[date]:
-    value = _pick(event, keys.get("updated", []))
-    if not value:
-        return None
-    parsed = _ensure_date(value)
-    return parsed
+def _country_iso(entry: Mapping[str, Any], aliases: Mapping[str, str]) -> Optional[str]:
+    iso = None
+    if isinstance(entry, Mapping):
+        if "iso3" in entry:
+            iso = str(entry.get("iso3") or "").strip()
+        elif "iso" in entry:
+            iso = str(entry.get("iso") or "").strip()
+        if iso:
+            resolved = to_iso3(iso, aliases)
+            if resolved:
+                return resolved
+        for key in ("name", "country", "countryname"):
+            if key in entry:
+                resolved = to_iso3(entry.get(key), aliases)
+                if resolved:
+                    return resolved
+    return None
 
 
-def _prepare_events(
-    raw_events: List[MutableMapping[str, Any]],
-    cfg: Dict[str, Any],
-    hazard_map: Dict[str, Sequence[str]],
-    default_hazard: str,
-    keys: Dict[str, Sequence[str]],
-    name_to_iso: Dict[str, str],
-) -> List[GDACSEvent]:
-    events: List[GDACSEvent] = []
-    for raw in raw_events:
-        iso_codes = _resolve_iso3(raw, keys, name_to_iso)
-        if not iso_codes:
-            dbg(f"skip event missing ISO3: {raw}")
-            continue
-        hazard = map_hazard(_pick(raw, keys.get("type", [])), hazard_map, default_hazard)
-        start_date = _ensure_date(_pick(raw, keys.get("start", [])))
-        end_date = _ensure_date(_pick(raw, keys.get("end", []))) or start_date
-        if not start_date:
-            dbg("skip event without start date")
-            continue
-        if end_date is None:
-            end_date = start_date
-        impact_field = ""
-        impact_value_raw: Optional[Any] = None
-        for candidate in keys.get("impact", []):
-            if candidate in raw and raw.get(candidate) not in (None, ""):
-                impact_field = candidate
-                impact_value_raw = raw.get(candidate)
-                break
-        impact_value = _parse_float(impact_value_raw)
-        if impact_value is None:
-            dbg("skip event without impact value")
-            continue
-        impact_int = int(round(impact_value))
-        if impact_int <= 0:
-            dbg("skip event with non-positive impact")
-            continue
-        event_id = str(_pick(raw, keys.get("id", [])) or "").strip()
-        if not event_id:
-            dbg("skip event missing id")
-            continue
-        episode_id = str(_pick(raw, keys.get("episode", [])) or "").strip()
-        source_url = str(_pick(raw, keys.get("url", [])) or "").strip()
-        doc_title = str(_pick(raw, keys.get("title", [])) or "").strip()
-        publication_date = _extract_publication_date(raw, keys)
-
-        for iso3 in iso_codes:
-            events.append(
-                GDACSEvent(
-                    event_id=event_id,
-                    episode_id=episode_id,
-                    iso3=iso3,
-                    hazard=hazard,
-                    start_date=start_date,
-                    end_date=end_date or start_date,
-                    impact_value=impact_int,
-                    source_url=source_url,
-                    doc_title=doc_title,
-                    publication_date=publication_date,
-                    impact_field=impact_field or "impact",
-                )
-            )
-    return events
+def _severity_value(event: Mapping[str, Any], severity_map: Mapping[str, int]) -> int:
+    raw = _pluck(event, "alertlevel", "severity", "alert")
+    if not raw:
+        return 0
+    text = str(raw).strip()
+    if not text:
+        return 0
+    value = severity_map.get(text)
+    if value is not None:
+        return int(value)
+    lowered = text.lower()
+    if lowered in severity_map:
+        return int(severity_map[lowered])
+    return int(DEFAULT_SEVERITY.get(lowered, 0))
 
 
-def dedupe_monthly_rows(
-    rows: Iterable[Dict[str, Any]],
-    strategy: str,
-) -> Dict[Tuple[str, str, str, str], Dict[str, Any]]:
-    strategy_norm = (strategy or "max").strip().lower()
-    per_key: Dict[Tuple[str, str, str, str], Dict[str, Any]] = {}
-    for row in rows:
-        key = (
-            row.get("event_ref", ""),
-            row.get("episode_id", ""),
-            row.get("iso3", ""),
-            row.get("as_of_date", ""),
-        )
-        value = int(row.get("value", 0))
-        if key not in per_key:
-            per_key[key] = dict(row)
-            per_key[key]["value"] = value
-            continue
-        if strategy_norm == "sum":
-            per_key[key]["value"] += value
-        else:
-            if value > int(per_key[key].get("value", 0)):
-                per_key[key] = dict(row)
-                per_key[key]["value"] = value
-    return per_key
+def _as_iso_date(value: Any) -> Optional[str]:
+    parsed = parse_date(value)
+    return parsed.isoformat() if parsed else None
 
 
-def _aggregate_final_rows(
-    rows: Iterable[Dict[str, Any]],
-    iso_to_name: Dict[str, str],
-    policy: str,
-    strategy: str,
-    publisher: str,
-    source_type: str,
-) -> List[Dict[str, Any]]:
-    aggregated: Dict[Tuple[str, str, str], Dict[str, Any]] = {}
-    for row in rows:
-        key = (row["iso3"], row["hazard_code"], row["as_of_date"])
-        bucket = aggregated.setdefault(
-            key,
-            {
-                "iso3": row["iso3"],
-                "hazard_code": row["hazard_code"],
-                "hazard_label": row["hazard_label"],
-                "hazard_class": row["hazard_class"],
-                "as_of_date": row["as_of_date"],
-                "value": 0,
-                "source_urls": set(),
-                "doc_titles": set(),
-                "event_refs": set(),
-                "episode_ids": set(),
-                "publication_dates": [],
-                "impact_fields": set(),
-            },
-        )
-        bucket["value"] += int(row.get("value", 0))
-        if row.get("source_url"):
-            bucket["source_urls"].add(str(row.get("source_url")))
-        if row.get("doc_title"):
-            bucket["doc_titles"].add(str(row.get("doc_title")))
-        if row.get("event_ref"):
-            bucket["event_refs"].add(str(row.get("event_ref")))
-        if row.get("episode_id"):
-            bucket["episode_ids"].add(str(row.get("episode_id")))
-        if row.get("publication_date"):
-            bucket["publication_dates"].append(row.get("publication_date"))
-        if row.get("impact_field" ):
-            bucket["impact_fields"].add(str(row.get("impact_field")))
-
-    final_rows: List[Dict[str, Any]] = []
-    ingested_at = datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
-    for key, bucket in aggregated.items():
-        iso3, hazard_code, as_of_month = key
-        country_name = iso_to_name.get(iso3, "")
-        value = int(bucket["value"])
-        if value <= 0:
-            continue
-        source_urls = sorted(bucket["source_urls"])
-        doc_titles = sorted(bucket["doc_titles"])
-        event_refs = sorted(bucket["event_refs"])
-        episode_ids = sorted(bucket["episode_ids"])
-        publication_dates = [d for d in bucket["publication_dates"] if d]
-        publication_date = ""
-        if publication_dates:
-            latest = max(publication_dates)
-            if isinstance(latest, date):
-                publication_date = latest.isoformat()
-            else:
-                publication_date = str(latest)
-        impact_fields = sorted(bucket["impact_fields"]) or ["impact"]
-        method = DEFAULT_METHOD.format(policy=policy)
-        definition_text = DEFAULT_DEFINITION.format(
-            fields="/".join(impact_fields), policy=policy, strategy=strategy
-        )
-        digest = _digest(
-            [
-                iso3,
-                hazard_code,
-                as_of_month,
-                value,
-                ";".join(source_urls),
-                ";".join(event_refs),
-                ";".join(episode_ids),
-            ]
-        )
-        year, month = as_of_month.split("-")
-        event_id = f"{iso3}-GDACS-{hazard_code}-{METRIC}-{year}-{month}-{digest}"
-        final_rows.append(
-            {
-                "event_id": event_id,
-                "country_name": country_name,
-                "iso3": iso3,
-                "hazard_code": hazard_code,
-                "hazard_label": bucket["hazard_label"],
-                "hazard_class": bucket["hazard_class"],
-                "metric": METRIC,
-                "series_semantics": SERIES_SEMANTICS,
-                "value": value,
-                "unit": UNIT,
-                "as_of_date": as_of_month,
-                "publication_date": publication_date,
-                "publisher": publisher,
-                "source_type": source_type,
-                "source_url": ";".join(source_urls),
-                "doc_title": "; ".join(doc_titles),
-                "definition_text": definition_text,
-                "method": method,
-                "confidence": "",
-                "revision": 0,
-                "ingested_at": ingested_at,
-            }
-        )
-    final_rows.sort(key=lambda r: (r["iso3"], r["hazard_code"], r["as_of_date"]))
-    return final_rows
+def _event_month(event: Mapping[str, Any]) -> Optional[date]:
+    for key in ("eventdate", "fromdate", "begindate", "startdate"):
+        candidate = _pluck(event, key)
+        parsed = month_start(candidate)
+        if parsed:
+            return parsed
+    updated = parse_date(_pluck(event, "updatedate", "lastupdate"))
+    if updated:
+        return updated.replace(day=1)
+    return None
 
 
-def _apply_max_results(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    cap = _env_int("RESOLVER_MAX_RESULTS")
-    if cap is None or cap <= 0:
-        return rows
-    return rows[:cap]
-
-
-def run(cfg: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
-    cfg = cfg or load_config()
-    if not cfg:
-        dbg("missing GDACS config; returning no rows")
-        return []
-    reason = _config_invalid_reason(cfg)
-    if reason:
-        dbg(f"invalid config reason: {reason}")
-        return []
-    skip = _env_bool("RESOLVER_SKIP_GDACS", False)
-    if skip:
-        dbg("RESOLVER_SKIP_GDACS=1 → skip network fetch")
-        return []
-
-    window_days = cfg.get("window_days", 60)
-    env_window = _env_int("GDACS_WINDOW_DAYS")
-    if env_window is not None and env_window > 0:
-        window_days = env_window
-    allocation_policy = os.getenv("GDACS_ALLOC_POLICY", cfg.get("allocation_policy", "prorata"))
-    dedup_strategy = os.getenv("GDACS_DEDUP_STRATEGY", cfg.get("dedup_strategy", "max"))
-    publisher = cfg.get("publisher", "GDACS")
-    source_type = cfg.get("source_type", "other")
-
-    hazard_map = cfg.get("hazard_map", {}) or {}
-    default_hazard = cfg.get("default_hazard", "other")
-    keys = cfg.get("keys", {}) or {}
-
-    iso_to_name, name_to_iso = load_countries()
-
+def fetch_events(cfg: Mapping[str, Any]) -> List[Dict[str, Any]]:
+    endpoints = dict(DEFAULT_ENDPOINTS)
+    endpoints.update(cfg.get("endpoints") or {})
+    window_days = int(cfg.get("window_days", 365) or 365)
     end_date = date.today()
-    start_date = end_date - timedelta(days=int(window_days))
+    start_date = end_date - timedelta(days=window_days)
+    session = _create_session()
+    tries = int(cfg.get("retry", {}).get("tries", 3) or 3)
+    backoff = float(cfg.get("retry", {}).get("backoff", 2.0) or 2.0)
+    params = {"from": start_date.isoformat(), "to": end_date.isoformat()}
+    url = endpoints.get("event_list") or DEFAULT_ENDPOINTS["event_list"]
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            response = session.get(url, params=params, timeout=120)
+            response.raise_for_status()
+            payload = response.json()
+            return _as_list(payload)
+        except requests.RequestException as exc:  # pragma: no cover - network
+            if attempt >= tries:
+                raise RuntimeError(f"GDACS event list request failed: {exc}") from exc
+            sleep_for = backoff * attempt
+            LOG.warning("gdacs event list failed; retrying", extra={"error": str(exc), "attempt": attempt})
+            time.sleep(sleep_for)
 
-    session = _prepare_session()
-    try:
-        raw_events = _fetch_event_list(session, cfg, start_date, end_date)
-    except Exception as exc:  # pragma: no cover - network failure
-        dbg(str(exc))
-        return []
 
-    enriched_events: List[MutableMapping[str, Any]] = []
-    for raw in raw_events:
-        enriched_events.append(_fetch_event_details(session, cfg, raw, keys))
-
-    gdacs_events = _prepare_events(
-        enriched_events,
-        cfg,
-        hazard_map,
-        default_hazard,
-        keys,
-        name_to_iso,
-    )
-
-    rows: List[Dict[str, Any]] = []
-    per_event_rows: List[Dict[str, Any]] = []
-    for event in gdacs_events:
-        allocations = allocate_event(event, allocation_policy)
-        for month, value in allocations.items():
-            per_event_rows.append(
-                {
-                    "event_ref": event.event_id,
-                    "episode_id": event.episode_id,
-                    "iso3": event.iso3,
-                    "hazard_code": event.hazard.code,
-                    "hazard_label": event.hazard.label,
-                    "hazard_class": event.hazard.hazard_class,
-                    "as_of_date": month,
-                    "value": value,
-                    "source_url": event.source_url,
-                    "doc_title": event.doc_title,
-                    "publication_date": event.publication_date,
-                    "impact_field": event.impact_field,
-                }
-            )
-
-    deduped = dedupe_monthly_rows(per_event_rows, dedup_strategy)
-    final_rows = _aggregate_final_rows(
-        deduped.values(),
-        iso_to_name,
-        allocation_policy,
-        dedup_strategy,
-        publisher,
-        source_type,
-    )
-    rows.extend(_apply_max_results(final_rows))
+def build_rows(cfg: Mapping[str, Any], events: Iterable[Mapping[str, Any]]) -> List[List[Any]]:
+    aliases = cfg.get("country_aliases") or {}
+    hazard_overrides = cfg.get("hazard_map") or {}
+    severity_map: dict[str, int] = {}
+    for key, value in DEFAULT_SEVERITY.items():
+        severity_map[key] = value
+    for key, value in (cfg.get("severity_map") or {}).items():
+        severity_map[str(key).strip().lower()] = int(value)
+    as_of_default = date.today().isoformat()
+    dedup: dict[tuple[str, str, str, str], Dict[str, Any]] = {}
+    for event in events:
+        hazard_token = _pluck(event, "eventtype", "hazardtype", "type")
+        hazard = map_hazard(hazard_token, hazard_overrides)
+        if not hazard:
+            continue
+        countries = _extract_countries(event)
+        if not countries:
+            continue
+        month = _event_month(event)
+        if not month:
+            continue
+        raw_event_id = _pluck(event, "eventid", "eventid", "id", "glide")
+        if not raw_event_id:
+            raw_event_id = _pluck(event, "name", "title")
+        month_iso = month.isoformat()
+        as_of = _as_iso_date(_pluck(event, "updatedate", "lastupdate", "pubdate")) or as_of_default
+        value = _severity_value(event, severity_map)
+        confidence = _pluck(event, "alertscore", "confidence")
+        raw_json = json.dumps({
+            "alertlevel": _pluck(event, "alertlevel"),
+            "eventid": raw_event_id,
+            "eventtype": hazard_token,
+            "countries": countries,
+        }, ensure_ascii=False)
+        for entry in countries:
+            iso3 = _country_iso(entry, aliases)
+            if not iso3:
+                continue
+            digest = stable_digest([iso3, hazard, month_iso, raw_event_id])
+            event_id = f"{iso3}-{hazard}-{month.strftime('%Y%m')}-{digest}"
+            key = (iso3, hazard, month_iso, str(raw_event_id))
+            record = {
+                "source": "gdacs",
+                "hazard_type": hazard,
+                "country_iso3": iso3,
+                "event_id": event_id,
+                "as_of": as_of,
+                "month_start": month_iso,
+                "value_type": "signal_level",
+                "value": value,
+                "unit": "",
+                "method": "gdacs_alert",
+                "confidence": str(confidence or "").strip(),
+                "raw_event_id": str(raw_event_id or ""),
+                "raw_fields_json": raw_json,
+            }
+            existing = dedup.get(key)
+            if existing:
+                if existing["as_of"] >= record["as_of"]:
+                    continue
+            dedup[key] = record
+    rows = [
+        [
+            record["source"],
+            record["hazard_type"],
+            record["country_iso3"],
+            record["event_id"],
+            record["as_of"],
+            record["month_start"],
+            record["value_type"],
+            record["value"],
+            record["unit"],
+            record["method"],
+            record["confidence"],
+            record["raw_event_id"],
+            record["raw_fields_json"],
+        ]
+        for record in dedup.values()
+    ]
+    rows.sort(key=lambda row: (row[2], row[1], row[5], row[11]))
     return rows
 
 
-def write_rows(rows: List[Dict[str, Any]]) -> None:
-    OUT_DIR.mkdir(parents=True, exist_ok=True)
-    df = pd.DataFrame(rows, columns=CANONICAL_HEADERS)
-    if df.empty:
-        df = pd.DataFrame(columns=CANONICAL_HEADERS)
-    df.to_csv(OUT_PATH, index=False)
+def write_rows(rows: List[List[Any]]) -> None:
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with OUTPUT_PATH.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(COLUMNS)
+        writer.writerows(rows)
+    ensure_manifest_for_csv(OUTPUT_PATH, schema_version="gdacs_signals.v1", source_id="gdacs")
 
 
-def main() -> bool:
-    if _env_bool("RESOLVER_SKIP_GDACS", False):
-        _write_header_only(OUT_PATH)
-        return False
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
     cfg = load_config()
-    reason = _config_invalid_reason(cfg)
-    if reason:
-        print(f"[gdacs] disabled/invalid config; writing header-only ({reason})")
-        dbg(f"invalid config reason: {reason}")
-        _write_header_only(OUT_PATH)
-        return False
+    if not cfg.get("enabled"):
+        LOG.info("gdacs: disabled via config; writing header only")
+        ensure_header_only()
+        return 0
     try:
-        rows = run(cfg)
-    except Exception as exc:  # pragma: no cover - defensive fail-soft
-        dbg(f"gdacs main failed: {exc}")
-        _write_header_only(OUT_PATH)
-        return False
-
-    if not rows:
-        _write_header_only(OUT_PATH)
-        return False
-
+        events = fetch_events(cfg)
+    except Exception as exc:  # noqa: BLE001
+        LOG.error("gdacs fetch failed", exc_info=exc)
+        raise
+    rows = build_rows(cfg, events)
     write_rows(rows)
-    return True
+    LOG.info("gdacs: wrote %s rows", len(rows))
+    return 0
 
 
-if __name__ == "__main__":  # pragma: no cover
-    main()
-
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/resolver/ingestion/schemas/dtm_displacement.schema.yml
+++ b/resolver/ingestion/schemas/dtm_displacement.schema.yml
@@ -1,0 +1,29 @@
+version: 1
+name: dtm_displacement
+columns:
+  - name: source
+    description: Data source identifier ("dtm").
+  - name: country_iso3
+    description: ISO3 country code represented by the row.
+  - name: admin1
+    description: Optional admin1 name when admin aggregation is enabled.
+  - name: event_id
+    description: Deterministic Resolver identifier for the (country, admin1, month) bucket.
+  - name: as_of
+    description: ISO8601 timestamp representing dataset freshness.
+  - name: month_start
+    description: First day of the month associated with the displacement flow.
+  - name: value_type
+    description: Metric name; for DTM this is "new_displaced".
+  - name: value
+    description: People count of new displaced persons for the month.
+  - name: unit
+    description: Unit for the value, typically "people".
+  - name: method
+    description: Processing pipeline and stock-to-flow rule used.
+  - name: confidence
+    description: Qualitative confidence if available.
+  - name: raw_event_id
+    description: Identifier built from source file/admin/month for deduplication.
+  - name: raw_fields_json
+    description: JSON blob preserving original source fields.

--- a/resolver/ingestion/schemas/emdat_pa.schema.yml
+++ b/resolver/ingestion/schemas/emdat_pa.schema.yml
@@ -1,0 +1,29 @@
+version: 1
+name: emdat_people_affected
+columns:
+  - name: source
+    description: Data source identifier ("emdat").
+  - name: hazard_type
+    description: Canonical hazard classification for the disaster.
+  - name: country_iso3
+    description: ISO3 country code associated with the record.
+  - name: event_id
+    description: Deterministic Resolver event identifier for the month bucket.
+  - name: as_of
+    description: ISO8601 timestamp representing latest dataset publication.
+  - name: month_start
+    description: First day of the month representing the allocation bucket.
+  - name: value_type
+    description: Impact metric emitted (affected, deaths, injured, homeless).
+  - name: value
+    description: People count for the metric in the given month.
+  - name: unit
+    description: Unit for value, typically "people".
+  - name: method
+    description: Allocation method label (e.g. emdat_linear_allocation).
+  - name: confidence
+    description: Qualitative confidence string when provided.
+  - name: raw_event_id
+    description: Native EM-DAT disaster identifier.
+  - name: raw_fields_json
+    description: JSON blob containing source fields for auditability.

--- a/resolver/ingestion/schemas/gdacs_signals.schema.yml
+++ b/resolver/ingestion/schemas/gdacs_signals.schema.yml
@@ -1,0 +1,29 @@
+version: 1
+name: gdacs_signals
+columns:
+  - name: source
+    description: Data source identifier ("gdacs").
+  - name: hazard_type
+    description: Canonical hazard name (e.g. earthquake, flood).
+  - name: country_iso3
+    description: ISO3 country code for the affected location.
+  - name: event_id
+    description: Deterministic Resolver event identifier.
+  - name: as_of
+    description: Timestamp when the alert was last updated (ISO8601 date).
+  - name: month_start
+    description: First day of the month representing the alert bucket.
+  - name: value_type
+    description: Metric captured; for GDACS this is "signal_level".
+  - name: value
+    description: Severity level mapped to numeric categories.
+  - name: unit
+    description: Unit for value (blank for GDACS alerts).
+  - name: method
+    description: Processing pipeline or allocation method label.
+  - name: confidence
+    description: Qualitative confidence string if available.
+  - name: raw_event_id
+    description: Native GDACS event identifier used for deduplication.
+  - name: raw_fields_json
+    description: JSON blob with key raw fields for traceability.

--- a/resolver/ingestion/utils/__init__.py
+++ b/resolver/ingestion/utils/__init__.py
@@ -1,0 +1,19 @@
+"""Shared ingestion utilities for Resolver connectors."""
+
+from .iso_normalize import to_iso3
+from .hazard_map import map_hazard
+from .month_bucket import month_start, parse_date, ym_first
+from .id_digest import stable_digest
+from .allocators import linear_split
+from .stock_to_flow import flow_from_stock
+
+__all__ = [
+    "to_iso3",
+    "map_hazard",
+    "month_start",
+    "parse_date",
+    "ym_first",
+    "stable_digest",
+    "linear_split",
+    "flow_from_stock",
+]

--- a/resolver/ingestion/utils/allocators.py
+++ b/resolver/ingestion/utils/allocators.py
@@ -1,0 +1,70 @@
+"""Allocation helpers used by monthly connectors."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Iterable, List, Tuple
+
+from .month_bucket import days_in_month_segment, month_start
+
+
+Number = float | int
+
+
+def linear_split(total: Number | None, start: date, end: date | None) -> List[Tuple[date, Number]]:
+    """Split ``total`` across months between ``start`` and ``end``."""
+
+    if total is None:
+        return []
+    try:
+        total_value = float(total)
+    except (TypeError, ValueError):
+        return []
+    if total_value <= 0:
+        return []
+    if not isinstance(start, date):
+        start = month_start(start)
+    if start is None:
+        return []
+    if end is None:
+        end = start
+    if not isinstance(end, date):
+        end = month_start(end)
+    if end is None:
+        end = start
+    if end < start:
+        end = start
+    allocations = days_in_month_segment(start, end)
+    if not allocations:
+        return [(start.replace(day=1), total)]
+    total_days = sum(allocations.values())
+    if total_days <= 0:
+        return [(start.replace(day=1), total)]
+    is_integer = float(total_value).is_integer()
+    results: list[tuple[date, Number]] = []
+    if is_integer:
+        integer_total = int(round(total_value))
+        base_values: dict[date, int] = {}
+        remainders: list[tuple[float, date]] = []
+        assigned = 0
+        for bucket, days in sorted(allocations.items()):
+            share = (total_value * days) / total_days
+            base = int(share)
+            base_values[bucket] = base
+            assigned += base
+            remainders.append((share - base, bucket))
+        remaining = integer_total - assigned
+        for _, bucket in sorted(remainders, key=lambda item: (-item[0], item[1])):
+            if remaining <= 0:
+                break
+            base_values[bucket] += 1
+            remaining -= 1
+        if remaining != 0:
+            last_bucket = max(base_values)
+            base_values[last_bucket] += remaining
+        results = sorted((bucket, value) for bucket, value in base_values.items() if value)
+    else:
+        for bucket, days in sorted(allocations.items()):
+            share = (total_value * days) / total_days
+            results.append((bucket, share))
+    return results

--- a/resolver/ingestion/utils/hazard_map.py
+++ b/resolver/ingestion/utils/hazard_map.py
@@ -1,0 +1,49 @@
+"""Utilities for normalising hazard labels to Resolver's canonical vocabulary."""
+
+from __future__ import annotations
+
+from typing import Mapping, Optional
+
+_DEFAULT_MAP = {
+    "eq": "earthquake",
+    "earthquake": "earthquake",
+    "fl": "flood",
+    "flood": "flood",
+    "tc": "tropical_cyclone",
+    "cyclone": "tropical_cyclone",
+    "storm": "tropical_cyclone",
+    "hurricane": "tropical_cyclone",
+    "volcano": "volcano",
+    "vo": "volcano",
+    "wf": "wildfire",
+    "wildfire": "wildfire",
+    "fire": "wildfire",
+    "ls": "landslide",
+    "landslide": "landslide",
+    "tsunami": "tsunami",
+    "dz": "drought",
+    "drought": "drought",
+    "conflict": "conflict",
+}
+
+
+def _normalise(token: str) -> str:
+    return "".join(ch for ch in token.lower() if ch.isalnum())
+
+
+def map_hazard(token: str | None, overrides: Optional[Mapping[str, str]] = None) -> Optional[str]:
+    """Return the canonical hazard string for ``token`` if known."""
+
+    if not token:
+        return None
+    normalised = _normalise(str(token))
+    if not normalised:
+        return None
+    if overrides:
+        for raw, canonical in overrides.items():
+            if _normalise(str(raw)) == normalised:
+                value = str(canonical).strip().lower()
+                return value or None
+    if normalised in _DEFAULT_MAP:
+        return _DEFAULT_MAP[normalised]
+    return None

--- a/resolver/ingestion/utils/id_digest.py
+++ b/resolver/ingestion/utils/id_digest.py
@@ -1,0 +1,19 @@
+"""Deterministic ID helpers."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Iterable
+
+
+def stable_digest(parts: Iterable[object], length: int = 12, algorithm: str = "sha1") -> str:
+    """Return a stable hexadecimal digest derived from ``parts``."""
+
+    text = "|".join(str(part or "") for part in parts)
+    if algorithm == "sha256":
+        digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    else:
+        digest = hashlib.sha1(text.encode("utf-8")).hexdigest()
+    if length > 0:
+        return digest[:length]
+    return digest

--- a/resolver/ingestion/utils/iso_normalize.py
+++ b/resolver/ingestion/utils/iso_normalize.py
@@ -1,0 +1,78 @@
+"""Helpers for normalising country identifiers to ISO3 codes."""
+
+from __future__ import annotations
+
+import csv
+from functools import lru_cache
+from pathlib import Path
+from typing import Mapping, Optional
+
+ROOT = Path(__file__).resolve().parents[2]
+COUNTRY_CSV = ROOT / "data" / "countries.csv"
+
+
+def _normalise_token(value: str) -> str:
+    return "".join(ch for ch in value.lower() if ch.isalnum())
+
+
+@lru_cache(maxsize=1)
+def _load_country_lookup() -> tuple[Mapping[str, str], Mapping[str, str]]:
+    iso_to_name: dict[str, str] = {}
+    token_to_iso: dict[str, str] = {}
+    if not COUNTRY_CSV.exists():
+        return iso_to_name, token_to_iso
+    with COUNTRY_CSV.open("r", encoding="utf-8-sig") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            iso = (row.get("iso3") or "").strip().upper()
+            name = (row.get("country_name") or "").strip()
+            if not iso:
+                continue
+            iso_to_name[iso] = name
+            if name:
+                token = _normalise_token(name)
+                if token:
+                    token_to_iso.setdefault(token, iso)
+    return iso_to_name, token_to_iso
+
+
+def _normalised_aliases(aliases: Mapping[str, str] | None) -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    if not aliases:
+        return mapping
+    for raw_key, raw_value in aliases.items():
+        key = _normalise_token(str(raw_key))
+        if not key:
+            continue
+        iso = str(raw_value or "").strip().upper()
+        if len(iso) == 3:
+            mapping[key] = iso
+    return mapping
+
+
+def to_iso3(name: str | None, aliases: Optional[Mapping[str, str]] = None) -> Optional[str]:
+    """Normalise ``name`` to an ISO3 code if possible."""
+
+    if not name:
+        return None
+    text = str(name).strip()
+    if not text:
+        return None
+    iso_to_name, token_lookup = _load_country_lookup()
+    candidate = text.upper()
+    if len(candidate) == 3 and candidate.isalpha():
+        if candidate in iso_to_name:
+            return candidate
+    alias_map = _normalised_aliases(aliases)
+    if alias_map:
+        token = _normalise_token(text)
+        alias_iso = alias_map.get(token)
+        if alias_iso:
+            return alias_iso
+    token = _normalise_token(text)
+    if token and token in token_lookup:
+        return token_lookup[token]
+    for iso, country in iso_to_name.items():
+        if text.lower() == country.lower():
+            return iso
+    return None

--- a/resolver/ingestion/utils/month_bucket.py
+++ b/resolver/ingestion/utils/month_bucket.py
@@ -1,0 +1,92 @@
+"""Date helpers for month bucket calculations."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from typing import Iterable, Optional
+
+_DATE_FORMATS: tuple[str, ...] = (
+    "%Y-%m-%d",
+    "%Y/%m/%d",
+    "%d-%m-%Y",
+    "%Y-%m",
+    "%Y%m%d",
+    "%Y%m",
+    "%Y-%m-%dT%H:%M:%SZ",
+    "%Y-%m-%dT%H:%M:%S",
+)
+
+
+def parse_date(value: object) -> Optional[date]:
+    """Parse ``value`` into a :class:`date` where possible."""
+
+    if value is None:
+        return None
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    text = str(value).strip()
+    if not text:
+        return None
+    for fmt in _DATE_FORMATS:
+        try:
+            parsed = datetime.strptime(text, fmt)
+            return parsed.date()
+        except ValueError:
+            continue
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return parsed.date()
+
+
+def month_start(value: object) -> Optional[date]:
+    """Return the first day of the month for ``value``."""
+
+    parsed = parse_date(value)
+    if not parsed:
+        return None
+    return parsed.replace(day=1)
+
+
+def ym_first(text: str | date | datetime) -> Optional[date]:
+    """Parse ``text`` as a ``YYYY-MM`` or ``YYYY-MM-01`` style string."""
+
+    if isinstance(text, (date, datetime)):
+        return month_start(text)
+    stripped = str(text or "").strip()
+    if not stripped:
+        return None
+    if len(stripped) == 7 and stripped[4] == "-":
+        stripped = f"{stripped}-01"
+    return month_start(stripped)
+
+
+def month_range(start: date, end: date) -> Iterable[date]:
+    """Yield the month starts between ``start`` and ``end`` inclusive."""
+
+    current = start.replace(day=1)
+    end_month = end.replace(day=1)
+    while current <= end_month:
+        yield current
+        year = current.year + (current.month // 12)
+        month = (current.month % 12) + 1
+        current = date(year, month, 1)
+
+
+def days_in_month_segment(start: date, end: date) -> dict[date, int]:
+    """Return inclusive day counts per month between ``start`` and ``end``."""
+
+    if end < start:
+        end = start
+    allocations: dict[date, int] = {}
+    cursor = start
+    while cursor <= end:
+        bucket = cursor.replace(day=1)
+        next_month = (bucket.replace(day=28) + timedelta(days=4)).replace(day=1)
+        segment_end = min(end, next_month - timedelta(days=1))
+        allocations[bucket] = allocations.get(bucket, 0) + (segment_end - cursor).days + 1
+        cursor = segment_end + timedelta(days=1)
+    return allocations

--- a/resolver/ingestion/utils/stock_to_flow.py
+++ b/resolver/ingestion/utils/stock_to_flow.py
@@ -1,0 +1,32 @@
+"""Convert stock series into non-negative monthly flows."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Mapping
+
+from .month_bucket import month_start
+
+Number = float | int
+
+
+def flow_from_stock(series_by_month: Mapping[date | str, Number]) -> dict[date, Number]:
+    """Return month-over-month non-negative differences for a stock series."""
+
+    normalised: dict[date, float] = {}
+    for key, value in series_by_month.items():
+        bucket = month_start(key)
+        if bucket is None:
+            continue
+        try:
+            normalised[bucket] = float(value)
+        except (TypeError, ValueError):
+            continue
+    flows: dict[date, float] = {}
+    previous_value = 0.0
+    for month in sorted(normalised):
+        current = normalised[month]
+        diff = current - previous_value
+        flows[month] = max(0.0, diff)
+        previous_value = current
+    return flows

--- a/resolver/ingestion/worldpop_client.py
+++ b/resolver/ingestion/worldpop_client.py
@@ -1,479 +1,167 @@
 #!/usr/bin/env python3
-"""WorldPop connector that writes population denominators for Resolver."""
+"""WorldPop denominators connector."""
 
 from __future__ import annotations
 
-import datetime as dt
-import io
-import os
-from dataclasses import dataclass
+import csv
+import logging
+from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Sequence
-from urllib.parse import urlparse
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
-import pandas as pd
-import requests
 import yaml
 
+from resolver.ingestion._manifest import ensure_manifest_for_csv
+from resolver.ingestion.utils import to_iso3
+
 ROOT = Path(__file__).resolve().parents[1]
-DATA = ROOT / "data"
 STAGING = ROOT / "staging"
-CONFIG = ROOT / "ingestion" / "config" / "worldpop.yml"
+CONFIG_PATH = ROOT / "ingestion" / "config" / "worldpop.yml"
+OUTPUT_PATH = STAGING / "worldpop_denominators.csv"
+DATA_DIR = ROOT / "data"
 
-OUT_DATA = DATA / "population.csv"
-OUT_STAGING = STAGING / "worldpop.csv"
+LOG = logging.getLogger("resolver.ingestion.worldpop")
 
-CANONICAL_COLUMNS = [
-    "iso3",
-    "year",
-    "population",
-    "source",
-    "product",
-    "download_date",
-    "source_url",
-    "notes",
-]
-
-DEBUG = os.getenv("RESOLVER_DEBUG", "0") == "1"
+COLUMNS = ["country_iso3", "year", "population", "as_of", "source", "method"]
 
 
-@dataclass
-class PopulationRow:
-    iso3: str
-    year: int
-    population: int
-    source: str
-    product: str
-    download_date: str
-    source_url: str
-    notes: str
+def load_config() -> dict[str, Any]:
+    if not CONFIG_PATH.exists():
+        return {}
+    with CONFIG_PATH.open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle) or {}
 
 
-class _DefaultDict(dict):
-    def __missing__(self, key: str) -> str:  # pragma: no cover - defensive
-        return "{" + key + "}"
+def ensure_header_only() -> None:
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with OUTPUT_PATH.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(COLUMNS)
+    ensure_manifest_for_csv(OUTPUT_PATH, schema_version="worldpop_denominators.v1", source_id="worldpop")
 
 
-def dbg(message: str) -> None:
-    if DEBUG:
-        print(f"[worldpop] {message}")
+def _dataset_path(cfg: Mapping[str, Any]) -> Path:
+    product = str(cfg.get("product") or "").strip()
+    candidate = cfg.get("dataset_path")
+    if candidate:
+        return Path(candidate)
+    if product:
+        preferred = DATA_DIR / f"{product}.csv"
+        if preferred.exists():
+            return preferred
+    fallback = DATA_DIR / "worldpop.csv"
+    if fallback.exists():
+        return fallback
+    return DATA_DIR / "population.csv"
 
 
-def _is_placeholder_url(url: str) -> bool:
-    text = str(url or "").strip()
-    if not text:
-        return True
-    lowered = text.lower()
-    if "<" in text or ">" in text:
-        return True
-    parsed = urlparse(text)
-    if not parsed.scheme or parsed.scheme not in {"http", "https"}:
-        return True
-    host = parsed.netloc.lower()
-    if not host:
-        return True
-    placeholder_hosts = (
-        "example.com",
-        "example.org",
-        "example.net",
-        "example.edu",
-        "example.gov",
-    )
-    if any(host == candidate or host.endswith(f".{candidate}") for candidate in placeholder_hosts):
-        return True
-    if "placeholder" in host:
-        return True
-    if "placeholder" in lowered:
-        return True
-    return False
+def _load_dataset(path: Path) -> List[Mapping[str, Any]]:
+    if not path.exists():
+        raise FileNotFoundError(f"WorldPop dataset not found: {path}")
+    with path.open("r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.DictReader(handle)
+        return list(reader)
 
 
-def _env_int(name: str, default: int) -> int:
-    value = os.getenv(name)
-    if value is None:
-        return default
-    try:
-        return int(value)
-    except Exception:  # pragma: no cover - defensive
-        return default
-
-
-def load_config() -> Dict[str, Any]:
-    with open(CONFIG, "r", encoding="utf-8") as fp:
-        data = yaml.safe_load(fp) or {}
-    return data
-
-
-def _ensure_population_header() -> None:
-    OUT_DATA.parent.mkdir(parents=True, exist_ok=True)
-    if not OUT_DATA.exists():
-        pd.DataFrame(columns=CANONICAL_COLUMNS).to_csv(OUT_DATA, index=False)
-
-
-def _write_header_only_staging() -> None:
-    OUT_STAGING.parent.mkdir(parents=True, exist_ok=True)
-    pd.DataFrame(columns=CANONICAL_COLUMNS).to_csv(OUT_STAGING, index=False)
-
-
-def _load_dataframe(url: str, *, kind: str = "csv") -> pd.DataFrame:
-    dbg(f"downloading {url}")
-    if url.startswith("http://") or url.startswith("https://"):
-        resp = requests.get(url, timeout=120)
-        if resp.status_code != 200:
-            raise RuntimeError(f"download failed: {url} status={resp.status_code}")
-        data = io.BytesIO(resp.content)
-    else:
-        data = url
-        if not Path(url).exists():
-            raise FileNotFoundError(f"source path missing: {url}")
-    if kind == "csv":
-        return pd.read_csv(data)
-    if kind in {"xlsx", "xls", "excel"}:
-        return pd.read_excel(data)
-    if kind == "json":
-        return pd.read_json(data)
-    return pd.read_csv(data)
-
-
-def _maybe_apply_hxl(df: pd.DataFrame) -> pd.DataFrame:
-    if df.empty:
-        return df
-    first_row = df.iloc[0]
-    if all(isinstance(v, str) and v.startswith("#") for v in first_row):
-        df = df.iloc[1:].reset_index(drop=True)
-        df.columns = [str(v).strip() for v in first_row]
-        return df
-    if all(isinstance(c, str) and c.startswith("#") for c in df.columns):
-        df.columns = [str(c).strip() for c in df.columns]
-        return df
-    return df
-
-
-def _normalise_columns(df: pd.DataFrame) -> Dict[str, str]:
-    mapping: Dict[str, str] = {}
-    for column in df.columns:
-        key = str(column).strip().lower()
-        mapping[key] = column
-    return mapping
-
-
-def _find_column(mapping: Dict[str, str], keys: Iterable[str]) -> Optional[str]:
-    for key in keys:
-        if not key:
-            continue
-        lowered = key.strip().lower()
-        if lowered in mapping:
-            return mapping[lowered]
-    return None
-
-
-def _parse_year(value: Any) -> Optional[int]:
-    if value is None:
-        return None
-    if isinstance(value, (int, float)) and not isinstance(value, bool):
-        if pd.isna(value):
-            return None
-        return int(value)
-    text = str(value).strip()
-    if not text:
-        return None
-    try:
-        number = int(float(text))
-    except Exception:
-        return None
-    return number
+def _read_existing() -> Dict[Tuple[str, int], Dict[str, Any]]:
+    if not OUTPUT_PATH.exists():
+        return {}
+    existing: Dict[Tuple[str, int], Dict[str, Any]] = {}
+    with OUTPUT_PATH.open("r", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            iso = str(row.get("country_iso3") or "").strip().upper()
+            try:
+                year = int(row.get("year"))
+            except (TypeError, ValueError):
+                continue
+            existing[(iso, year)] = dict(row)
+    return existing
 
 
 def _parse_population(value: Any) -> Optional[int]:
     if value is None:
         return None
     if isinstance(value, (int, float)) and not isinstance(value, bool):
-        if pd.isna(value):
-            return None
         return int(round(float(value)))
     text = str(value).strip()
     if not text:
         return None
-    cleaned = text.replace(",", "")
     try:
-        number = float(cleaned)
-    except Exception:
+        return int(float(text.replace(",", "")))
+    except ValueError:
         return None
-    if pd.isna(number):
-        return None
-    return int(round(number))
 
 
-def _format_url(template: str, *, product: str, year: str | int) -> str:
-    placeholders = _DefaultDict(product=product, year=year)
-    return template.format_map(placeholders)
-
-
-def _collect_from_frame(
-    df: pd.DataFrame,
-    *,
-    keys_cfg: Dict[str, Sequence[str]],
-    prefer_hxl: bool,
-    source: str,
-    product: str,
-    download_date: str,
-    source_url: str,
-) -> List[PopulationRow]:
-    if df is None or df.empty:
-        return []
-    if prefer_hxl:
-        df = _maybe_apply_hxl(df)
-    else:
-        df.columns = [str(c).strip() for c in df.columns]
-
-    mapping = _normalise_columns(df)
-    iso_col = _find_column(mapping, keys_cfg.get("iso3", []))
-    year_col = _find_column(mapping, keys_cfg.get("year", []))
-    pop_col = _find_column(mapping, keys_cfg.get("population", []))
-    notes_col = _find_column(mapping, keys_cfg.get("notes", []))
-
-    if not iso_col or not pop_col:
-        return []
-
-    rows: List[PopulationRow] = []
-    for _, row in df.iterrows():
-        iso_raw = row.get(iso_col)
-        if pd.isna(iso_raw):
+def build_rows(cfg: Mapping[str, Any]) -> List[List[Any]]:
+    dataset = _load_dataset(_dataset_path(cfg))
+    aliases = cfg.get("country_aliases") or {}
+    years = [int(y) for y in cfg.get("years", []) if str(y).isdigit()]
+    if not years:
+        raise ValueError("worldpop config must include years list")
+    as_of = datetime.utcnow().date().isoformat()
+    source = "worldpop"
+    method = str(cfg.get("product") or "worldpop_national")
+    updates: Dict[Tuple[str, int], Dict[str, Any]] = {}
+    for row in dataset:
+        iso = to_iso3(row.get("iso3"), aliases) or to_iso3(row.get("country"), aliases)
+        if not iso:
             continue
-        iso3 = str(iso_raw).strip().upper()
-        if not iso3 or len(iso3) != 3:
+        try:
+            year = int(row.get("year"))
+        except (TypeError, ValueError):
             continue
-        year_val = _parse_year(row.get(year_col)) if year_col else None
-        if year_val is None:
+        if year not in years:
             continue
-        pop_val = _parse_population(row.get(pop_col))
-        if pop_val is None or pop_val <= 0:
+        population = _parse_population(row.get("population"))
+        if population is None:
             continue
-        notes_val = ""
-        if notes_col:
-            notes_raw = row.get(notes_col)
-            if isinstance(notes_raw, str):
-                notes_val = notes_raw.strip()
-            elif notes_raw is not None and not pd.isna(notes_raw):
-                notes_val = str(notes_raw).strip()
-        rows.append(
-            PopulationRow(
-                iso3=iso3,
-                year=year_val,
-                population=pop_val,
-                source=source,
-                product=product,
-                download_date=download_date,
-                source_url=source_url,
-                notes=notes_val,
-            )
-        )
+        updates[(iso, year)] = {
+            "country_iso3": iso,
+            "year": year,
+            "population": population,
+            "as_of": as_of,
+            "source": source,
+            "method": method,
+        }
+    existing = _read_existing()
+    existing.update(updates)
+    rows = [
+        [
+            data["country_iso3"],
+            data["year"],
+            data["population"],
+            data["as_of"],
+            data["source"],
+            data["method"],
+        ]
+        for data in existing.values()
+    ]
+    rows.sort(key=lambda row: (row[0], int(row[1])))
     return rows
 
 
-def collect_rows() -> List[PopulationRow]:
+def write_rows(rows: List[List[Any]]) -> None:
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with OUTPUT_PATH.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(COLUMNS)
+        writer.writerows(rows)
+    ensure_manifest_for_csv(OUTPUT_PATH, schema_version="worldpop_denominators.v1", source_id="worldpop")
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
     cfg = load_config()
-    product_env = os.getenv("WORLDPOP_PRODUCT")
-    product = (product_env or cfg.get("product") or "un_adj_unconstrained").strip()
-    years_back = _env_int("WORLDPOP_YEARS_BACK", int(cfg.get("years_back", 0)))
-    prefer_hxl = bool(cfg.get("prefer_hxl", False))
-    keys_cfg = cfg.get("keys", {})
-    source_cfg = cfg.get("source", {})
-    source_label = source_cfg.get("publisher", "WorldPop")
-    url_template_env = os.getenv("WORLDPOP_URL_TEMPLATE")
-    url_template = url_template_env or source_cfg.get("url_template")
-    static_url = source_cfg.get("url")
-    source_kind = (source_cfg.get("kind") or "csv").lower()
-    download_date = dt.date.today().isoformat()
-
-    for candidate in (url_template, static_url):
-        if candidate and _is_placeholder_url(str(candidate)):
-            print("[worldpop] disabled/placeholder config; header-only")
-            dbg(f"placeholder url detected: {candidate}")
-            return []
-
-    if not url_template and not static_url:
-        raise RuntimeError("worldpop config missing url or url_template")
-
-    collected: Dict[tuple[str, int], PopulationRow] = {}
-    seen_years: set[int] = set()
-
-    def _register(rows: List[PopulationRow]) -> None:
-        for row in rows:
-            key = (row.iso3, row.year)
-            collected[key] = row
-            seen_years.add(row.year)
-
-    targets: List[tuple[int, str]] = []
-
-    if url_template:
-        latest_url = _format_url(url_template, product=product, year="latest")
-        targets.append((-1, latest_url))
-    elif static_url:
-        targets.append((-1, static_url))
-
-    for hint, url in targets:
-        try:
-            df = _load_dataframe(url, kind=source_kind)
-        except Exception as exc:
-            dbg(f"failed to load {url}: {exc}")
-            continue
-        rows = _collect_from_frame(
-            df,
-            keys_cfg=keys_cfg,
-            prefer_hxl=prefer_hxl,
-            source=source_label,
-            product=product,
-            download_date=download_date,
-            source_url=url,
-        )
-        _register(rows)
-
-    if not collected:
-        return []
-
-    latest_year = max(seen_years)
-
-    if years_back > 0 and url_template:
-        for offset in range(1, years_back + 1):
-            year = latest_year - offset
-            if year < 0:
-                continue
-            url = _format_url(url_template, product=product, year=year)
-            try:
-                df = _load_dataframe(url, kind=source_kind)
-            except Exception as exc:
-                dbg(f"failed to load {url}: {exc}")
-                continue
-            rows = _collect_from_frame(
-                df,
-                keys_cfg=keys_cfg,
-                prefer_hxl=prefer_hxl,
-                source=source_label,
-                product=product,
-                download_date=download_date,
-                source_url=url,
-            )
-            if not rows:
-                continue
-            _register(rows)
-
-    filtered: List[PopulationRow] = []
-    grouped: Dict[tuple[str, str], List[PopulationRow]] = {}
-    for row in collected.values():
-        grouped.setdefault((row.iso3, row.product), []).append(row)
-
-    for (iso3, product_label), rows in grouped.items():
-        years = {row.year for row in rows}
-        if not years:
-            continue
-        iso_max_year = max(years)
-        iso_min_year = (
-            iso_max_year - years_back if years_back >= 0 else iso_max_year
-        )
-        kept_years = []
-        for row in rows:
-            if iso_min_year <= row.year <= iso_max_year:
-                filtered.append(row)
-                kept_years.append(row.year)
-        if DEBUG:
-            kept_years_sorted = sorted(set(kept_years))
-            dbg(
-                f"{iso3} product={product_label!r} kept years={kept_years_sorted} "
-                f"(iso_max={iso_max_year}, years_back={years_back})"
-            )
-
-    filtered.sort(key=lambda r: (r.iso3, r.product, r.year))
-    return filtered
-
-
-def _load_existing() -> pd.DataFrame:
-    if not OUT_DATA.exists():
-        return pd.DataFrame(columns=CANONICAL_COLUMNS)
-    df = pd.read_csv(OUT_DATA)
-    if df.empty:
-        return pd.DataFrame(columns=CANONICAL_COLUMNS)
-    df["iso3"] = df["iso3"].astype(str).str.upper()
-    df["year"] = df["year"].apply(lambda x: _parse_year(x) or 0)
-    df["population"] = df["population"].apply(lambda x: _parse_population(x) or 0)
-    df["notes"] = df.get("notes", "").fillna("")
-    df = df[(df["iso3"].astype(bool)) & (df["population"] > 0)]
-    if "year" in df:
-        df = df[df["year"] > 0]
-    return df.reset_index(drop=True)
-
-
-def _merge_population(existing: pd.DataFrame, rows: List[PopulationRow]) -> tuple[pd.DataFrame, int, int]:
-    if not rows:
-        return existing, 0, 0
-    inserted = 0
-    updated = 0
-    result = existing.copy()
-    if result.empty:
-        data = [row.__dict__ for row in rows]
-        df = pd.DataFrame(data, columns=CANONICAL_COLUMNS)
-        return df, len(rows), 0
-
-    for row in rows:
-        mask = (result["iso3"] == row.iso3) & (result["year"] == row.year)
-        row_dict = {
-            "iso3": row.iso3,
-            "year": int(row.year),
-            "population": int(row.population),
-            "source": row.source,
-            "product": row.product,
-            "download_date": row.download_date,
-            "source_url": row.source_url,
-            "notes": row.notes or "",
-        }
-        if mask.any():
-            for column, value in row_dict.items():
-                result.loc[mask, column] = value
-            updated += 1
-        else:
-            result = pd.concat([result, pd.DataFrame([row_dict])], ignore_index=True)
-            inserted += 1
-    result = result.drop_duplicates(subset=["iso3", "year"], keep="last")
-    result.sort_values(["iso3", "year"], inplace=True, ignore_index=True)
-    return result, inserted, updated
-
-
-def _write_outputs(rows: List[PopulationRow]) -> tuple[int, int, int]:
-    existing = _load_existing()
-    merged, inserted, updated = _merge_population(existing, rows)
-    merged.to_csv(OUT_DATA, index=False)
-
-    stage_df = pd.DataFrame([row.__dict__ for row in rows], columns=CANONICAL_COLUMNS)
-    OUT_STAGING.parent.mkdir(parents=True, exist_ok=True)
-    stage_df.to_csv(OUT_STAGING, index=False)
-    return len(rows), inserted, updated
-
-
-def main() -> bool:
-    if os.getenv("RESOLVER_SKIP_WORLDPOP") == "1":
-        dbg("RESOLVER_SKIP_WORLDPOP=1 — writing headers only")
-        _ensure_population_header()
-        _write_header_only_staging()
-        return False
-
-    try:
-        rows = collect_rows()
-    except Exception as exc:
-        dbg(f"collect_rows failed: {exc}")
-        _ensure_population_header()
-        _write_header_only_staging()
-        return False
-
-    if not rows:
-        dbg("no WorldPop rows collected; writing headers")
-        _ensure_population_header()
-        _write_header_only_staging()
-        return False
-
-    count, inserted, updated = _write_outputs(rows)
-    print(f"WorldPop wrote {count} rows (inserted={inserted}, updated={updated})")
-    return True
+    if not cfg.get("enabled"):
+        LOG.info("worldpop: disabled via config; writing header only")
+        ensure_header_only()
+        return 0
+    rows = build_rows(cfg)
+    write_rows(rows)
+    LOG.info("worldpop: wrote %s rows", len(rows))
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add shared ingestion utilities for ISO normalisation, hazard mapping, month buckets, deterministic IDs, allocation, and stock-to-flow transforms
- implement real GDACS, EM-DAT, DTM, and WorldPop connectors that honour config toggles and emit new staging outputs with schema docs
- update connector configs, runner logging, and ingestion README with enablement matrix and behaviour notes

## Testing
- pytest resolver/ingestion/tests

------
https://chatgpt.com/codex/tasks/task_e_68e0f29c8598832c83102ea1c1f1ccf0