### PR TITLE
Restore UNHCR registry signature and add helper

### DIFF
--- a/SCHEMAS.md
+++ b/SCHEMAS.md
@@ -42,3 +42,8 @@
 - `RESOLVER_DEBUG=1` enables detailed debug logging and summary counters for UNHCR ingestion clients.
 - `UNHCR_TEST_ISO3=GRC` (or `test_iso3` in `resolver/ingestion/config/unhcr.yml`) narrows Population API runs to the specified country for smoke testing.
 - Summary counters include `raw_count`, `after_keymap`, `after_date_parse`, `after_country_match`, `after_window`, `final_rows`, `dropped_value_cast`, `dropped_country_unmatched`, `country_unmatched`, and `page_cap_hit`.
+
+## Registry helpers
+
+- `load_registries()` returns `(countries_df, shocks_df)` for ingestion clients.
+- Use `build_country_name_index(countries_df)` to derive the UNHCR country name → ISO3 lookup when needed.

--- a/resolver/tests/test_unhcr_paging_guards.py
+++ b/resolver/tests/test_unhcr_paging_guards.py
@@ -62,6 +62,7 @@ def test_unhcr_make_rows_handles_json_error(monkeypatch):
 
     monkeypatch.setattr(unhcr_client.requests, "get", lambda *_, **__: _Response())
 
-    rows = unhcr_client.make_rows()
+    rows, counters = unhcr_client.make_rows()
 
     assert rows == []
+    assert counters == unhcr_client.Counter()


### PR DESCRIPTION
## Summary
- restore `load_registries()` in the UNHCR client to return only the countries and shocks tables
- add `build_country_name_index()` helper and use it to build the ISO3 lookup in the UNHCR ingestion path
- align the UNHCR paging guard test and documentation with the preserved registry API

## Testing
- pytest resolver/tests/test_unhcr_paging_guards.py

------
https://chatgpt.com/codex/tasks/task_e_68e0f6125198832cb03c1273ff6720f4