### PR TITLE
Fix DTM dedup to ignore stale admin rows

### DIFF
--- a/resolver/ingestion/README.md
+++ b/resolver/ingestion/README.md
@@ -54,6 +54,7 @@ Each connector:
 - **DTM displacement**: Stock tables convert to monthly flows using the non-negative
   difference rule; flows are preserved as-is. National totals equal the sum of admin1 rows when the
   config sets `admin_agg: both`.
+  - Deduplication keeps the most recent `as_of` per `(country, admin1, month, source)`; older or equal timestamps are skipped to prevent regressions.
 - **WorldPop denominators**: Upserts replace previously written `(iso3, year)` rows so reruns update
   `as_of` timestamps without duplicating records.
 

--- a/resolver/ingestion/dtm_client.py
+++ b/resolver/ingestion/dtm_client.py
@@ -42,6 +42,16 @@ COLUMNS = [
 DEFAULT_CAUSE = "unknown"
 
 
+def _is_candidate_newer(existing_iso: str, candidate_iso: str) -> bool:
+    """Return True when the candidate `as_of` timestamp is strictly newer."""
+
+    if not candidate_iso:
+        return False
+    if not existing_iso:
+        return True
+    return candidate_iso > existing_iso
+
+
 def load_config() -> dict[str, Any]:
     if not CONFIG_PATH.exists():
         return {}
@@ -232,8 +242,8 @@ def build_rows(cfg: Mapping[str, Any]) -> List[List[Any]]:
                 ),
             }
             existing = dedup.get(key)
-            if existing and existing["as_of"] >= record["as_of"]:
-                pass
+            if existing and not _is_candidate_newer(existing["as_of"], record["as_of"]):
+                continue
             dedup[key] = record
         if admin_mode in {"country", "both"}:
             country_totals[(iso3, month_iso, rec["source_id"])] += value

--- a/resolver/ingestion/tests/test_dtm_dedup.py
+++ b/resolver/ingestion/tests/test_dtm_dedup.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from resolver.ingestion import dtm_client
+
+
+def _apply_admin_dedup(records: Iterable[dict[str, str | int]]) -> dict[str, str | int]:
+    """Replicate the admin-level dedup logic for a single key."""
+
+    key = ("NGA", "Borno", "2025-09-01", "dtm_source")
+    dedup: dict[tuple[str, str, str, str], dict[str, str | int]] = {}
+    for record in records:
+        existing = dedup.get(key)
+        if existing and not dtm_client._is_candidate_newer(existing["as_of"], record["as_of"]):
+            continue
+        dedup[key] = record
+    return dedup[key]
+
+
+def test_dtm_dedup_prefers_newer_and_skips_equal() -> None:
+    """Newer `as_of` wins; equal timestamps keep the first record."""
+
+    def make_record(as_of: str, value: int) -> dict[str, str | int]:
+        return {
+            "source": "dtm",
+            "country_iso3": "NGA",
+            "admin1": "Borno",
+            "event_id": f"NGA-displacement-202509-{as_of}",
+            "as_of": as_of,
+            "month_start": "2025-09-01",
+            "value_type": "new_displaced",
+            "value": value,
+            "unit": "people",
+            "method": "dtm_flow",
+            "confidence": "unknown",
+            "raw_event_id": "dtm_source::Borno::202509",
+            "raw_fields_json": "{}",
+        }
+
+    # Candidate with a newer as_of should replace the older record.
+    newer_result = _apply_admin_dedup(
+        [make_record("2025-10-01", 100), make_record("2025-10-03", 500)]
+    )
+    assert newer_result["as_of"] == "2025-10-03"
+    assert newer_result["value"] == 500
+
+    # A stale candidate arriving after a newer record must be ignored.
+    stale_result = _apply_admin_dedup(
+        [make_record("2025-10-03", 500), make_record("2025-10-01", 100)]
+    )
+    assert stale_result["as_of"] == "2025-10-03"
+    assert stale_result["value"] == 500
+
+    # Equal timestamps should keep the first record (stable ordering, no flapping).
+    equal_result = _apply_admin_dedup(
+        [make_record("2025-10-01", 100), make_record("2025-10-01", 999)]
+    )
+    assert equal_result["as_of"] == "2025-10-01"
+    assert equal_result["value"] == 100


### PR DESCRIPTION
## Summary
- ensure DTM admin dedup logic only replaces rows when a candidate has a newer `as_of`
- document the DTM connector's as_of-aware deduplication behavior
- add unit coverage for newer, stale, and equal `as_of` scenarios

## Testing
- pytest resolver/ingestion/tests/test_dtm_dedup.py

------
https://chatgpt.com/codex/tasks/task_e_68e0f6e42534832c87c64269f0a3c54b