### PR TITLE
feat: add connector enable gating and CLI filters

### DIFF
--- a/resolver/ingestion/config/acled.yml
+++ b/resolver/ingestion/config/acled.yml
@@ -1,3 +1,4 @@
+enable: false
 base_url: "https://api.acleddata.com/acled/read"
 window_days: 450
 limit: 1000

--- a/resolver/ingestion/config/dtm.yml
+++ b/resolver/ingestion/config/dtm.yml
@@ -1,3 +1,4 @@
+enable: false
 enabled: false
 sources:
   - type: file

--- a/resolver/ingestion/config/emdat.yml
+++ b/resolver/ingestion/config/emdat.yml
@@ -1,3 +1,4 @@
+enable: false
 enabled: false
 source:
   type: file

--- a/resolver/ingestion/config/gdacs.yml
+++ b/resolver/ingestion/config/gdacs.yml
@@ -1,3 +1,4 @@
+enable: false
 enabled: false
 window_days: 365
 retry:

--- a/resolver/ingestion/config/hdx.yml
+++ b/resolver/ingestion/config/hdx.yml
@@ -1,3 +1,4 @@
+enable: false
 base_url: https://data.humdata.org
 query_text: people in need
 prefer_hxl: true

--- a/resolver/ingestion/config/ifrc_go.yml
+++ b/resolver/ingestion/config/ifrc_go.yml
@@ -1,3 +1,4 @@
+enable: false
 base_url: "https://goadmin.ifrc.org/api/v2/"
 user_agent: "spagbot-resolver/1.0 (github.com/kwyjad/Spagbot_metac-bot)"
 window_days: 45

--- a/resolver/ingestion/config/ipc.yml
+++ b/resolver/ingestion/config/ipc.yml
@@ -1,3 +1,4 @@
+enable: false
 enabled: false
 dayfirst: false
 feeds: []

--- a/resolver/ingestion/config/reliefweb.yml
+++ b/resolver/ingestion/config/reliefweb.yml
@@ -1,3 +1,4 @@
+enable: false
 appname: "UNICEF-Resolver-P1L1T6"
 user_agent: "UNICEF-Resolver-P1L1T6/1.0 (+https://unicef.org/emops; contact=resolver@unicef.org)"
 base_url: "https://api.reliefweb.int/v2/reports"

--- a/resolver/ingestion/config/unhcr.yml
+++ b/resolver/ingestion/config/unhcr.yml
@@ -1,3 +1,4 @@
+enable: false
 base_url: "https://api.unhcr.org/population/v1/"
 user_agent: "spagbot-resolver/1.0 (github.com/kwyjad/Spagbot_metac-bot)"
 window_days: 60

--- a/resolver/ingestion/config/unhcr_odp.yml
+++ b/resolver/ingestion/config/unhcr_odp.yml
@@ -1,3 +1,4 @@
+enable: false
 situation_path: "/en/situations/europe-sea-arrivals"
 
 series:

--- a/resolver/ingestion/config/wfp_mvam.yml
+++ b/resolver/ingestion/config/wfp_mvam.yml
@@ -1,3 +1,4 @@
+enable: false
 sources:
   - name: mvam_ifc_global
     kind: csv

--- a/resolver/ingestion/config/wfp_mvam_sources.yml
+++ b/resolver/ingestion/config/wfp_mvam_sources.yml
@@ -1,3 +1,4 @@
+enable: false
 enabled: false
 sources: []
 auth: {}

--- a/resolver/ingestion/config/who_phe.yml
+++ b/resolver/ingestion/config/who_phe.yml
@@ -1,3 +1,4 @@
+enable: false
 enabled: false
 sources:
   cholera_global:

--- a/resolver/ingestion/config/worldpop.yml
+++ b/resolver/ingestion/config/worldpop.yml
@@ -1,3 +1,4 @@
+enable: false
 enabled: true
 product: unadj_national_totals
 years:

--- a/resolver/ingestion/feature_flags.py
+++ b/resolver/ingestion/feature_flags.py
@@ -1,0 +1,89 @@
+"""Helper utilities for connector enable flags and overrides.
+
+All ingestion connector YAML configs now expose a top-level ``enable`` boolean
+which defaults to ``false`` in the repository so that heavy network calls are
+skipped in CI by default.  Local developers can override these guards by
+setting ``RESOLVER_FORCE_ENABLE`` (for example, ``RESOLVER_FORCE_ENABLE=acled``)
+without editing the YAML files.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, Mapping, Set
+
+
+def norm(name: str | os.PathLike[str] | None) -> str:
+    """Normalise connector names for comparison.
+
+    Names are lower-cased, spaces and hyphens are replaced with underscores, the
+    ``.py``/``.yml``/``.yaml`` suffix is removed, and common connector suffixes
+    like ``_client``/``_stub`` are stripped.  This allows callers to use the
+    same identifier for ``RESOLVER_FORCE_ENABLE``, ``--only`` arguments, or
+    configuration file stems.
+    """
+
+    if name is None:
+        return ""
+    value = str(name).strip().lower()
+    if not value:
+        return ""
+    value = value.replace(" ", "_").replace("-", "_")
+    for suffix in (".py", ".yml", ".yaml"):
+        if value.endswith(suffix):
+            value = value[: -len(suffix)]
+            break
+    for suffix in ("_client", "_stub"):
+        if value.endswith(suffix):
+            value = value[: -len(suffix)]
+    return value.strip("_")
+
+
+def parse_force_enable(env_val: str | None) -> Set[str]:
+    """Parse ``RESOLVER_FORCE_ENABLE`` environment variable into a set."""
+
+    if not env_val:
+        return set()
+    entries = (part.strip() for part in str(env_val).split(","))
+    normalised = {norm(part) for part in entries if part.strip()}
+    return {item for item in normalised if item}
+
+
+def _coerce_cfg(cfg: object) -> Dict[str, object]:
+    return cfg if isinstance(cfg, dict) else {}
+
+
+def is_enabled(
+    name: str,
+    cfg: Dict[str, object] | None,
+    env: Mapping[str, str] | None = None,
+) -> bool:
+    """Return ``True`` if the connector should run.
+
+    ``cfg`` should be the parsed YAML mapping for the connector.  ``env``
+    defaults to :mod:`os.environ`.  ``RESOLVER_FORCE_ENABLE`` always wins over
+    the config flag.
+    """
+
+    if env is None:
+        env = os.environ
+    cfg_dict = _coerce_cfg(cfg)
+    cfg_enable = bool(cfg_dict.get("enable", False))
+    forced = norm(name) in parse_force_enable(env.get("RESOLVER_FORCE_ENABLE"))
+    return forced or cfg_enable
+
+
+def explain_enable(
+    name: str,
+    cfg: Dict[str, object] | None,
+    env: Mapping[str, str] | None = None,
+) -> str:
+    """Return a short reason string for why a connector is enabled/disabled."""
+
+    if env is None:
+        env = os.environ
+    cfg_dict = _coerce_cfg(cfg)
+    cfg_enable = bool(cfg_dict.get("enable", False))
+    if norm(name) in parse_force_enable(env.get("RESOLVER_FORCE_ENABLE")):
+        return "forced_by_env"
+    return "config_enabled" if cfg_enable else "config_disabled"


### PR DESCRIPTION
## Summary
- add a resolver.ingestion.feature_flags helper to parse enable overrides and normalization
- set enable: false defaults across ingestion configs to keep connectors off in CI and honour RESOLVER_FORCE_ENABLE
- teach run_all_stubs to respect the new enable flags, log decisions, and add --only/--pattern filters

## Testing
- python -m compileall resolver/ingestion

------
https://chatgpt.com/codex/tasks/task_e_68e0ff3d6e18832cb79fcd4af841e231