### PR TITLE
Fix nightly resolver workflow schedule and indentation

### DIFF
--- a/.github/workflows/resolver-ci-nightly.yml
+++ b/.github/workflows/resolver-ci-nightly.yml
@@ -2,7 +2,7 @@ name: resolver-ci-nightly
 
 on:
   schedule:
-    - cron: "17 1 * * *"
+    - cron: "0 23 * * *"
   workflow_dispatch: {}
 
 permissions:
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   full_connectors:
-    if: ${{ github.event_name != 'push' && github.event_name != 'pull_request' || !contains(github.event.head_commit.message || '', '[skip-ci]') }}
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -67,17 +67,17 @@ jobs:
           JOB_STATUS: ${{ job.status }}
         run: |
           python - <<'PY'
-import json
-import os
-from pathlib import Path
+          import json
+          import os
+          from pathlib import Path
 
-connector = os.environ["CONNECTOR"]
-status = os.environ.get("JOB_STATUS", "unknown")
-log_dir = Path("resolver/logs/ingestion")
-log_dir.mkdir(parents=True, exist_ok=True)
-summary_path = log_dir / f"{connector}-job-status.json"
-summary_path.write_text(json.dumps({"connector": connector, "job_status": status}))
-PY
+          connector = os.environ["CONNECTOR"]
+          status = os.environ.get("JOB_STATUS", "unknown")
+          log_dir = Path("resolver/logs/ingestion")
+          log_dir.mkdir(parents=True, exist_ok=True)
+          summary_path = log_dir / f"{connector}-job-status.json"
+          summary_path.write_text(json.dumps({"connector": connector, "job_status": status}))
+          PY
       - name: Upload nightly artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -90,7 +90,7 @@ PY
           retention-days: 7
 
   aggregate:
-    if: ${{ always() }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
     needs: full_connectors
     runs-on: ubuntu-latest
     steps:
@@ -102,65 +102,65 @@ PY
       - name: Build summary
         run: |
           python - <<'PY'
-import csv
-import json
-from pathlib import Path
+          import csv
+          import json
+          from pathlib import Path
 
-root = Path("nightly-artifacts")
-records = []
-for status_file in root.rglob("*-job-status.json"):
-    try:
-        data = json.loads(status_file.read_text())
-    except json.JSONDecodeError:
-        continue
-    connector = data.get("connector") or status_file.stem.replace("-job-status", "")
-    job_status = data.get("job_status", "unknown")
-    record = {
-        "connector": connector,
-        "job_status": job_status,
-        "status": "unknown",
-        "attempts": None,
-        "duration_ms": None,
-        "notes": None,
-    }
-    log_dir = status_file.parent
-    for log_file in sorted(log_dir.glob("*")):
-        if not log_file.is_file():
-            continue
-        try:
-            lines = log_file.read_text().splitlines()
-        except Exception:
-            continue
-        for line in lines:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                payload = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            if payload.get("event") == "connector_summary":
-                record.update(
-                    {
-                        "status": payload.get("status", record["status"]),
-                        "attempts": payload.get("attempts", record["attempts"]),
-                        "duration_ms": payload.get("duration_ms", record["duration_ms"]),
-                        "notes": payload.get("notes", record["notes"]),
-                    }
-                )
-    records.append(record)
-records.sort(key=lambda item: item["connector"] or "")
-summary_dir = Path("nightly-summary")
-summary_dir.mkdir(exist_ok=True)
-json_path = summary_dir / "summary.json"
-csv_path = summary_dir / "summary.csv"
-json_path.write_text(json.dumps(records, indent=2, sort_keys=True))
-with csv_path.open("w", newline="", encoding="utf-8") as handle:
-    writer = csv.DictWriter(handle, fieldnames=["connector", "job_status", "status", "attempts", "duration_ms", "notes"])
-    writer.writeheader()
-    for row in records:
-        writer.writerow(row)
-PY
+          root = Path("nightly-artifacts")
+          records = []
+          for status_file in root.rglob("*-job-status.json"):
+              try:
+                  data = json.loads(status_file.read_text())
+              except json.JSONDecodeError:
+                  continue
+              connector = data.get("connector") or status_file.stem.replace("-job-status", "")
+              job_status = data.get("job_status", "unknown")
+              record = {
+                  "connector": connector,
+                  "job_status": job_status,
+                  "status": "unknown",
+                  "attempts": None,
+                  "duration_ms": None,
+                  "notes": None,
+              }
+              log_dir = status_file.parent
+              for log_file in sorted(log_dir.glob("*")):
+                  if not log_file.is_file():
+                      continue
+                  try:
+                      lines = log_file.read_text().splitlines()
+                  except Exception:
+                      continue
+                  for line in lines:
+                      line = line.strip()
+                      if not line:
+                          continue
+                      try:
+                          payload = json.loads(line)
+                      except json.JSONDecodeError:
+                          continue
+                      if payload.get("event") == "connector_summary":
+                          record.update(
+                              {
+                                  "status": payload.get("status", record["status"]),
+                                  "attempts": payload.get("attempts", record["attempts"]),
+                                  "duration_ms": payload.get("duration_ms", record["duration_ms"]),
+                                  "notes": payload.get("notes", record["notes"]),
+                              }
+                          )
+              records.append(record)
+          records.sort(key=lambda item: item["connector"] or "")
+          summary_dir = Path("nightly-summary")
+          summary_dir.mkdir(exist_ok=True)
+          json_path = summary_dir / "summary.json"
+          csv_path = summary_dir / "summary.csv"
+          json_path.write_text(json.dumps(records, indent=2, sort_keys=True))
+          with csv_path.open("w", newline="", encoding="utf-8") as handle:
+              writer = csv.DictWriter(handle, fieldnames=["connector", "job_status", "status", "attempts", "duration_ms", "notes"])
+              writer.writeheader()
+              for row in records:
+                  writer.writerow(row)
+          PY
       - name: Upload nightly summary
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- update the nightly workflow cron to run at 02:00 Istanbul time and skip push/PR triggers
- fix YAML indentation so embedded Python steps are parsed correctly and keep aggregator guarded by the same trigger filter

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e29c745e5c832ca1ff5360d88afaa6