### PR TITLE
Add ReliefWeb PDF ingestion with OCR and PPH conversion

### DIFF
--- a/resolver/docs/reliefweb_pdf.md
+++ b/resolver/docs/reliefweb_pdf.md
@@ -1,0 +1,106 @@
+# ReliefWeb PDF ingestion
+
+This document explains how the ReliefWeb PDF extension behaves inside the
+Resolver ingestion pipeline.  The connector augments the classic
+`reliefweb_client.py` API workflow by downloading report attachments, extracting
+figures, and writing them to `staging/reliefweb_pdf.csv` in the canonical facts
+schema.
+
+## Overview
+
+- The connector uses the ReliefWeb API to discover resources that contain
+  `application/pdf` attachments.
+- A heuristic chooses the most relevant PDF per report.  Preferences are defined
+  in the configuration via `preferred_pdf_titles` (e.g. “Situation Report”,
+  “Flash Update”, “Key Figures”).
+- PDFs are downloaded once and cached under `staging/.cache/reliefweb/pdf/`.
+- Text extraction first attempts native text and falls back to OCR when the
+  native layer is sparse.  OCR can be disabled in configuration or during tests.
+- Parsed metrics include `people_in_need`, `people_affected`, and `idps`.  When
+  only household counts are provided, the connector converts them to people
+  using the reference `avg_household_size.csv` file.
+- Output rows are emitted per country with `tier=2`, deterministic `event_id`
+  hashes, and `series_semantics="new"` monthly deltas.  The level value is
+  stored in `value_level` while `value` represents the new monthly value.
+
+## Configuration
+
+The ReliefWeb configuration (`ingestion/config/reliefweb.yml`) exposes the
+following keys:
+
+| Key | Description | Default |
+| --- | --- | --- |
+| `enable_pdfs` | Toggle PDF parsing | `true` |
+| `enable_ocr` | Allow OCR fallback | `true` |
+| `min_text_chars_before_ocr` | Native text length threshold before OCR | `1500` |
+| `preferred_pdf_titles` | Ordered list of substrings used by the selection heuristic | see config |
+| `since_months` | Look-back window for reports when PDF ingestion is run standalone | `6` |
+
+To disable OCR entirely, set `enable_ocr: false`.  Tests can also monkeypatch
+`resolver.ingestion._pdf_text.PDF_TEXT_TEST_MODE` to avoid heavyweight OCR.
+
+## People-per-household (PPH)
+
+Household → people conversions use `reference/avg_household_size.csv` merged with
+overrides from `reference/overrides/avg_household_size_overrides.yml`.  The
+lookup returns the best match for an ISO3 code and falls back to a global
+default of `4.5` people per household.  The chosen value is surfaced via the
+`method_details` column (`PPH=<value>, source=<source>, year=<year>`).
+
+To override PPH values for a project, edit the overrides YAML file, e.g.:
+
+```yaml
+overrides:
+  USA:
+    people_per_household: 2.60
+    source: "Custom Study"
+    year: 2024
+    notes: "Hurricane-specific household composition"
+```
+
+## Date logic and deltas
+
+The connector extracts an `as_of_date` from the PDF by prioritising:
+
+1. Coverage or reporting period end dates (`Reporting period: 01–31 Aug 2025`).
+2. A `Report date:` field in the document body.
+3. ReliefWeb metadata timestamps.
+
+Monthly deltas follow Resolver’s standard rule: compare the current level value
+with the previous level for the same `(iso3, hazard_code, metric, source_family`
+=`reliefweb_pdf`) lineage.  Level history is cached under
+`staging/.cache/reliefweb/levels/levels.json`.
+
+## Output schema
+
+`staging/reliefweb_pdf.csv` uses the following columns:
+
+```
+event_id,country_name,iso3,hazard_code,hazard_label,hazard_class,
+metric,series_semantics,value,unit,value_level,as_of_date,month_start,
+publication_date,publisher,source_type,source_url,resource_url,doc_title,
+definition_text,method,method_value,method_details,extraction_layer,
+matched_phrase,tier,confidence,revision,ingested_at
+```
+
+- `value` is the monthly new figure.
+- `value_level` stores the level extracted from the PDF.
+- `method_value` captures whether the figure was reported directly or derived
+  from households.
+- `method_details` records PPH and extraction hints.
+- `extraction_layer` identifies the winning parsing layer (`table`,
+  `infographic`, `narrative`).
+
+Each PDF run updates the manifest via `reliefweb_pdf.csv.meta.json` and logs the
+row count in the CLI output.
+
+## Troubleshooting
+
+- **OCR performance:** when OCR is unexpectedly triggered, increase
+  `min_text_chars_before_ocr` or disable OCR.
+- **Ambiguous multi-country totals:** the parser skips values that cannot be
+  allocated to a single country.  Check logs for `ambiguous_allocation` notes.
+- **Missing PPH:** add ISO3 values to `avg_household_size.csv` or the overrides
+  file.  Without an entry the global default (4.5) is used.
+- **Caching:** remove `staging/.cache/reliefweb/pdf/` to force re-download of
+  PDFs and `staging/.cache/reliefweb/levels/` to reset monthly deltas.

--- a/resolver/ingestion/_pdf_text.py
+++ b/resolver/ingestion/_pdf_text.py
@@ -1,0 +1,207 @@
+"""Utilities for extracting text from ReliefWeb PDF resources.
+
+The real ReliefWeb connector relies on a combination of native PDF text
+extraction and OCR fallbacks.  The implementation below keeps the production
+behaviour lightweight while remaining extremely easy to monkeypatch inside the
+unit test-suite.  The helpers expose a common API that mirrors the production
+connector, but they avoid hard dependencies on heavy third-party libraries when
+they are not available in the runtime environment.
+
+The functions are intentionally small, feature measurable logging hooks and are
+written in a way that allows tests to inject fake implementations.  When OCR is
+not available, the helpers degrade gracefully by returning an empty string so
+that callers can decide how to react.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import logging
+import time
+from typing import Callable, Dict, List, Optional, Tuple
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+# Global switches used by the test-suite.  The connector imports this module
+# directly which makes these variables trivial to monkeypatch using
+# ``monkeypatch.setattr``.
+PDF_TEXT_TEST_MODE = False
+_NATIVE_EXTRACTOR: Optional[Callable[[bytes], str]] = None
+_OCR_EXTRACTOR: Optional[
+    Callable[[bytes, Optional[List[str]], Optional[List[int]]], str]
+] = None
+
+
+def _default_native_extractor(content_bytes: bytes) -> str:
+    """Extract text using ``pdfminer.six`` when available."""
+
+    try:  # Deferred import keeps the connector light when pdfminer is absent.
+        from pdfminer.high_level import extract_text as pdfminer_extract_text
+    except Exception:  # pragma: no cover - optional dependency
+        LOGGER.debug("pdfminer not available; returning empty native text")
+        return ""
+
+    with io.BytesIO(content_bytes) as fh:
+        try:
+            text = pdfminer_extract_text(fh)
+        except Exception as exc:  # pragma: no cover - defensive branch
+            LOGGER.warning("pdfminer extraction failed: %s", exc)
+            return ""
+    return text or ""
+
+
+def _default_ocr_extractor(
+    content_bytes: bytes,
+    languages: Optional[List[str]] = None,
+    page_mask: Optional[List[int]] = None,
+) -> str:
+    """Perform OCR using ``pytesseract`` + ``pdf2image`` when available."""
+
+    try:  # Deferred imports keep optional dependencies truly optional.
+        from pdf2image import convert_from_bytes
+        import pytesseract
+    except Exception:  # pragma: no cover - optional dependency
+        LOGGER.debug("OCR libraries not available; returning empty text")
+        return ""
+
+    pages = convert_from_bytes(content_bytes)
+    if page_mask is not None:
+        to_process = [idx for idx in page_mask if 0 <= idx < len(pages)]
+    else:
+        to_process = list(range(len(pages)))
+
+    if not to_process:
+        to_process = list(range(len(pages)))
+
+    texts: List[str] = []
+    for page_index in to_process:
+        image = pages[page_index]
+        try:
+            page_text = pytesseract.image_to_string(
+                image, lang="+".join(languages) if languages else None
+            )
+        except Exception as exc:  # pragma: no cover - defensive branch
+            LOGGER.warning("OCR failed on page %s: %s", page_index, exc)
+            page_text = ""
+        texts.append(page_text)
+    return "\n".join(texts)
+
+
+def _get_native_extractor() -> Callable[[bytes], str]:
+    return _NATIVE_EXTRACTOR or _default_native_extractor
+
+
+def _get_ocr_extractor() -> Callable[[bytes, Optional[List[str]], Optional[List[int]]], str]:
+    return _OCR_EXTRACTOR or _default_ocr_extractor
+
+
+def extract_text_from_pdf(content_bytes: bytes) -> str:
+    """Return the native text extracted from the PDF."""
+
+    start = time.perf_counter()
+    text = _get_native_extractor()(content_bytes)
+    LOGGER.debug(
+        "pdf.native chars=%s elapsed_ms=%0.2f",
+        len(text),
+        (time.perf_counter() - start) * 1000,
+    )
+    return text
+
+
+def ocr_pdf_bytes(
+    content_bytes: bytes,
+    languages: Optional[List[str]] = None,
+    page_mask: Optional[List[int]] = None,
+) -> str:
+    """Return OCR text extracted from the PDF."""
+
+    start = time.perf_counter()
+    text = _get_ocr_extractor()(content_bytes, languages, page_mask)
+    LOGGER.debug(
+        "pdf.ocr chars=%s pages=%s elapsed_ms=%0.2f",
+        len(text),
+        [] if page_mask is None else page_mask,
+        (time.perf_counter() - start) * 1000,
+    )
+    return text
+
+
+def smart_extract(content_bytes: bytes, min_chars: int = 1500) -> Tuple[str, Dict[str, object]]:
+    """Extract text using native parsing with a selective OCR fallback."""
+
+    native_text = extract_text_from_pdf(content_bytes)
+    meta: Dict[str, object] = {
+        "method": "native",
+        "chars": len(native_text),
+        "pages_ocrd": [],
+        "digest": hashlib.sha256(content_bytes).hexdigest(),
+    }
+    if len(native_text) >= min_chars or not native_text.strip():
+        return native_text, meta
+
+    # OCR fallback.  We only attempt OCR when explicitly enabled outside of
+    # tests.  During tests we keep the behaviour deterministic by respecting
+    # ``PDF_TEXT_TEST_MODE`` which callers can toggle.
+    if PDF_TEXT_TEST_MODE:
+        return native_text, meta
+
+    # Re-run native extraction for each page to identify candidates with little
+    # text.  The simple heuristic below works well in practice and is cheap.
+    try:
+        from pdfminer.high_level import extract_text_to_fp
+        from pdfminer.pdfpage import PDFPage
+    except Exception:  # pragma: no cover - optional dependency
+        LOGGER.debug("pdfminer not available for selective OCR; OCRing full doc")
+        ocr_text = ocr_pdf_bytes(content_bytes)
+        meta.update({"method": "ocr", "chars": len(ocr_text)})
+        return ocr_text, meta
+
+    pages_to_ocr: List[int] = []
+    page_texts: List[str] = []
+    with io.BytesIO(content_bytes) as fh:
+        for page_index, page in enumerate(PDFPage.get_pages(fh)):
+            # We need a fresh BytesIO for ``extract_text_to_fp`` because the
+            # helper consumes from the beginning of the file.  ``PDFPage`` has
+            # already moved ``fh`` to the start of the next page so we re-open
+            # a dedicated buffer per iteration.
+            sub_buffer = io.BytesIO(content_bytes)
+            buffer = io.StringIO()
+            try:
+                extract_text_to_fp(sub_buffer, buffer, page_numbers=[page_index])
+            except Exception:  # pragma: no cover - defensive branch
+                page_texts.append("")
+                pages_to_ocr.append(page_index)
+                continue
+            text = buffer.getvalue()
+            page_texts.append(text)
+            if len(text.strip()) < max(50, min_chars // 10):
+                pages_to_ocr.append(page_index)
+
+    ocr_text = ocr_pdf_bytes(content_bytes, page_mask=pages_to_ocr or None)
+    if not ocr_text:
+        return native_text, meta
+
+    combined = []
+    for idx, page_text in enumerate(page_texts):
+        if idx in pages_to_ocr:
+            combined.append(ocr_text)
+        combined.append(page_text)
+    merged_text = "\n".join(filter(None, combined)) or ocr_text
+
+    meta.update({"method": "hybrid", "chars": len(merged_text), "pages_ocrd": pages_to_ocr})
+    return merged_text, meta
+
+
+def install_test_extractors(
+    native: Optional[Callable[[bytes], str]] = None,
+    ocr: Optional[Callable[[bytes, Optional[List[str]], Optional[List[int]]], str]] = None,
+) -> None:
+    """Install in-memory extractors used exclusively by the tests."""
+
+    global _NATIVE_EXTRACTOR, _OCR_EXTRACTOR
+    _NATIVE_EXTRACTOR = native
+    _OCR_EXTRACTOR = ocr
+

--- a/resolver/ingestion/config/reliefweb.yml
+++ b/resolver/ingestion/config/reliefweb.yml
@@ -3,6 +3,20 @@ appname: "UNICEF-Resolver-P1L1T6"
 user_agent: "UNICEF-Resolver-P1L1T6/1.0 (+https://unicef.org/emops; contact=resolver@unicef.org)"
 base_url: "https://api.reliefweb.int/v2/reports"
 accept_header: "application/json"
+enable_pdfs: true
+enable_ocr: true
+min_text_chars_before_ocr: 1500
+since_months: 6
+preferred_pdf_titles:
+  - "situation report"
+  - "sitrep"
+  - "flash report"
+  - "flash update"
+  - "snapshot"
+  - "appeal"
+  - "humanitarian update"
+  - "key figures"
+  - "response update"
 max_retries: 6
 retry_backoff_seconds: 2
 timeout_seconds: 30

--- a/resolver/ingestion/reliefweb_client.py
+++ b/resolver/ingestion/reliefweb_client.py
@@ -15,12 +15,15 @@ Usage:
 from __future__ import annotations
 
 import datetime as dt
+import json
+import logging
 import os
 import random
 import re
 import time
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import pandas as pd
 import requests
@@ -28,12 +31,24 @@ import yaml
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
+from resolver.ingestion._manifest import ensure_manifest_for_csv
+from resolver.ingestion import _pdf_text as pdf_text_mod
+from resolver.ingestion._pdf_text import smart_extract
+from resolver.ingestion.utils.id_digest import stable_digest
+from resolver.ingestion.utils.io import ensure_headers
+from resolver.ingestion.utils.month_bucket import month_start
+
 ROOT = Path(__file__).resolve().parents[1]
 DATA = ROOT / "data"
 STAGING = ROOT / "staging"
 CONFIG = ROOT / "ingestion" / "config" / "reliefweb.yml"
+REFERENCE = ROOT / "reference"
+PDF_CACHE = STAGING / ".cache" / "reliefweb" / "pdf"
+LEVEL_CACHE = STAGING / ".cache" / "reliefweb" / "levels"
 
 DEBUG = os.getenv("RESOLVER_DEBUG", "0") == "1"
+
+LOGGER = logging.getLogger("resolver.ingestion.reliefweb")
 
 COUNTRIES = DATA / "countries.csv"
 SHOCKS = DATA / "shocks.csv"
@@ -62,6 +77,678 @@ COLUMNS = [
     "revision",
     "ingested_at",
 ]
+
+PDF_COLUMNS = [
+    "event_id",
+    "country_name",
+    "iso3",
+    "hazard_code",
+    "hazard_label",
+    "hazard_class",
+    "metric",
+    "series_semantics",
+    "value",
+    "unit",
+    "value_level",
+    "as_of_date",
+    "month_start",
+    "publication_date",
+    "publisher",
+    "source_type",
+    "source_url",
+    "resource_url",
+    "doc_title",
+    "definition_text",
+    "method",
+    "method_value",
+    "method_details",
+    "extraction_layer",
+    "matched_phrase",
+    "tier",
+    "confidence",
+    "revision",
+    "ingested_at",
+]
+
+PDF_OUTPUT = STAGING / "reliefweb_pdf.csv"
+
+DEFAULT_PPH = 4.5
+PPH_TABLE = REFERENCE / "avg_household_size.csv"
+PPH_OVERRIDES = REFERENCE / "overrides" / "avg_household_size_overrides.yml"
+
+TABLE_METRIC_SYNONYMS = {
+    "people_in_need": [
+        "people in need",
+        "in need",
+        "total in need",
+        "pin",
+    ],
+    "people_affected": [
+        "people affected",
+        "affected people",
+        "population affected",
+    ],
+    "idps": [
+        "internally displaced",
+        "idp",
+        "displaced (internal)",
+        "displaced persons",
+    ],
+    "households_in_need": [
+        "households in need",
+        "hh in need",
+    ],
+    "households_affected": [
+        "households affected",
+        "hh affected",
+    ],
+}
+
+INFOGRAPHIC_HEADINGS = [
+    "key figures",
+    "key figure",
+    "at a glance",
+    "snapshot",
+]
+
+NARRATIVE_PATTERNS = {
+    "people_in_need": re.compile(
+        r"(?P<value>[0-9][0-9.,\s]*\+?(?:\s*(?:k|m|million))?)\s+people\s+in\s+need",
+        re.I,
+    ),
+    "people_affected": re.compile(
+        r"(?P<value>[0-9][0-9.,\s]*\+?(?:\s*(?:k|m|million))?)\s+(?:people|persons)\s+affected",
+        re.I,
+    ),
+    "idps": re.compile(
+        r"(?P<value>[0-9][0-9.,\s]*\+?(?:\s*(?:k|m|million))?)\s+(?:idps?|internally displaced)",
+        re.I,
+    ),
+}
+
+HOUSEHOLD_TO_PEOPLE = {
+    "households_in_need": "people_in_need",
+    "households_affected": "people_affected",
+}
+
+LAYER_PRIORITY = {"table": 0, "infographic": 1, "narrative": 2}
+
+
+@dataclass
+class PPHEntry:
+    iso3: str
+    people_per_household: float
+    source: str
+    year: Optional[int]
+    notes: str = ""
+
+    def describe(self) -> str:
+        bits = [f"PPH={self.people_per_household:.2f}"]
+        if self.source:
+            bits.append(f"source={self.source}")
+        if self.year:
+            bits.append(f"year={self.year}")
+        if self.notes:
+            bits.append(self.notes)
+        return ", ".join(bits)
+
+
+@dataclass
+class MetricCandidate:
+    metric: str
+    value: int
+    unit: str
+    layer: str
+    matched_phrase: str
+    method_value: str = "reported"
+    method_details: str = ""
+    country_iso3: Optional[str] = None
+    extraction_meta: Dict[str, Any] = field(default_factory=dict)
+
+
+class PPHLookup:
+    """Load people-per-household values with overrides."""
+
+    def __init__(self) -> None:
+        self._table: Dict[str, PPHEntry] = {}
+        self._loaded = False
+
+    def _load(self) -> None:
+        if self._loaded:
+            return
+        table: Dict[str, PPHEntry] = {}
+        if PPH_TABLE.exists():
+            df = pd.read_csv(PPH_TABLE)
+            for _, row in df.iterrows():
+                try:
+                    value = float(row["people_per_household"])
+                except (KeyError, ValueError, TypeError):
+                    continue
+                iso3 = str(row.get("iso3", "")).strip().upper()
+                if not iso3:
+                    continue
+                table[iso3] = PPHEntry(
+                    iso3=iso3,
+                    people_per_household=value,
+                    source=str(row.get("source", "")),
+                    year=int(row["year"]) if not pd.isna(row.get("year")) else None,
+                    notes=str(row.get("notes", "")),
+                )
+        if PPH_OVERRIDES.exists():
+            with open(PPH_OVERRIDES, "r", encoding="utf-8") as handle:
+                data = yaml.safe_load(handle) or {}
+            overrides = data.get("overrides", {}) or {}
+            for iso3, payload in overrides.items():
+                iso3_norm = str(iso3).strip().upper()
+                if not iso3_norm:
+                    continue
+                value = payload.get("people_per_household")
+                if value is None:
+                    continue
+                entry = table.get(iso3_norm)
+                year = payload.get("year")
+                table[iso3_norm] = PPHEntry(
+                    iso3=iso3_norm,
+                    people_per_household=float(value),
+                    source=str(payload.get("source", getattr(entry, "source", ""))),
+                    year=int(year) if year is not None else getattr(entry, "year", None),
+                    notes=str(payload.get("notes", getattr(entry, "notes", ""))),
+                )
+        self._table = table
+        self._loaded = True
+
+    def lookup(self, iso3: str) -> PPHEntry:
+        self._load()
+        key = (iso3 or "").strip().upper()
+        entry = self._table.get(key)
+        if entry:
+            return entry
+        return PPHEntry(iso3=key or "GLOBAL", people_per_household=DEFAULT_PPH, source="default", year=None)
+
+
+PPH = PPHLookup()
+
+
+def _clean_text(text: str) -> str:
+    return (text or "").replace("\u202f", " ").replace("\xa0", " ")
+
+
+def _parse_number(token: str) -> Optional[int]:
+    if token is None:
+        return None
+    cleaned = _clean_text(token).strip().lower()
+    if not cleaned:
+        return None
+    multiplier = 1.0
+    if cleaned.endswith("million"):
+        multiplier = 1_000_000.0
+        cleaned = cleaned[:-7].strip()
+    elif cleaned.endswith("m"):
+        multiplier = 1_000_000.0
+        cleaned = cleaned[:-1].strip()
+    elif cleaned.endswith("k"):
+        multiplier = 1_000.0
+        cleaned = cleaned[:-1].strip()
+    cleaned = cleaned.replace(",", "")
+    try:
+        value = float(cleaned)
+    except ValueError:
+        return None
+    normalized = int(round(value * multiplier))
+    if normalized < 0:
+        return None
+    return normalized
+
+
+def _extract_value_from_line(line: str) -> Optional[int]:
+    match = re.search(r"([0-9][0-9.,\s]*(?:k|m|million)?)", line, re.I)
+    if not match:
+        return None
+    return _parse_number(match.group(1))
+
+
+def select_best_pdf(resources: List[Dict[str, Any]], preferred_titles: Iterable[str]) -> Optional[Dict[str, Any]]:
+    if not resources:
+        return None
+    prefs = [p.lower() for p in preferred_titles]
+
+    def score(resource: Dict[str, Any]) -> Tuple[int, dt.datetime, int]:
+        name = _clean_text(
+            resource.get("name")
+            or resource.get("description")
+            or resource.get("title")
+            or ""
+        ).lower()
+        matches = 0
+        for pref in prefs:
+            if pref and pref in name:
+                matches = max(matches, len(pref))
+        created_text = resource.get("date", {}).get("created") or resource.get("created")
+        try:
+            created = dt.datetime.fromisoformat(created_text.replace("Z", "+00:00"))
+        except Exception:
+            created = dt.datetime.fromtimestamp(0, tz=dt.timezone.utc)
+        pages = int(resource.get("page_count") or 0)
+        return matches, created, pages
+
+    ranked = sorted(resources, key=score, reverse=True)
+    return ranked[0]
+
+
+def _split_table_line(line: str) -> Optional[List[str]]:
+    if "|" in line:
+        return [cell.strip() for cell in line.split("|") if cell.strip()]
+    if "\t" in line:
+        return [cell.strip() for cell in line.split("\t") if cell.strip()]
+    if re.search(r"\s{2,}", line):
+        return [cell.strip() for cell in re.split(r"\s{2,}", line) if cell.strip()]
+    return None
+
+
+def _find_table_candidates(text: str, country_names: Dict[str, str]) -> List[MetricCandidate]:
+    lines = [_clean_text(line) for line in text.splitlines()]
+    split_lines = [(_split_table_line(line), line) for line in lines]
+    header_idx = None
+    header_map: Dict[str, int] = {}
+    for idx, (cells, raw) in enumerate(split_lines):
+        if not cells or len(cells) < 2:
+            continue
+        lowered = [cell.lower() for cell in cells]
+        for metric, synonyms in TABLE_METRIC_SYNONYMS.items():
+            for synonym in synonyms:
+                if synonym in lowered:
+                    header_map[metric] = lowered.index(synonym)
+        if header_map:
+            header_idx = idx
+            break
+    candidates: List[MetricCandidate] = []
+    if header_idx is None:
+        # Try line level detection without header (key figures style)
+        for _, raw_line in split_lines:
+            if not raw_line:
+                continue
+            low = raw_line.lower()
+            for metric, synonyms in TABLE_METRIC_SYNONYMS.items():
+                if any(s in low for s in synonyms):
+                    value = _extract_value_from_line(raw_line)
+                    if value is None:
+                        continue
+                    candidates.append(
+                        MetricCandidate(
+                            metric=metric,
+                            value=value,
+                            unit="persons" if not metric.startswith("household") else "households",
+                            layer="infographic",
+                            matched_phrase=raw_line.strip(),
+                        )
+                    )
+        return candidates
+
+    # Parse rows after header
+    for idx in range(header_idx + 1, len(split_lines)):
+        cells, raw = split_lines[idx]
+        if not cells or len(cells) < 2:
+            continue
+        first_cell = cells[0].lower()
+        iso_match = None
+        for iso3, name in country_names.items():
+            if name.lower() in first_cell or iso3.lower() in first_cell:
+                iso_match = iso3
+                break
+        for metric, col_idx in header_map.items():
+            if col_idx >= len(cells):
+                continue
+            value = _parse_number(cells[col_idx])
+            if value is None:
+                continue
+            candidates.append(
+                MetricCandidate(
+                    metric=metric,
+                    value=value,
+                    unit="persons" if not metric.startswith("household") else "households",
+                    layer="table",
+                    matched_phrase=raw.strip(),
+                    country_iso3=iso_match,
+                )
+            )
+    return candidates
+
+
+def _find_infographic_candidates(text: str) -> List[MetricCandidate]:
+    candidates: List[MetricCandidate] = []
+    lowered = _clean_text(text).lower()
+    for heading in INFOGRAPHIC_HEADINGS:
+        idx = lowered.find(heading)
+        if idx == -1:
+            continue
+        window = text[idx : idx + 400]
+        for metric, synonyms in TABLE_METRIC_SYNONYMS.items():
+            for synonym in synonyms:
+                pattern = re.compile(rf"{re.escape(synonym)}[\s:]+([^\n]+)", re.I)
+                match = pattern.search(window)
+                if not match:
+                    continue
+                value = _parse_number(match.group(1))
+                if value is None:
+                    continue
+                candidates.append(
+                    MetricCandidate(
+                        metric=metric,
+                        value=value,
+                        unit="persons" if not metric.startswith("household") else "households",
+                        layer="infographic",
+                        matched_phrase=match.group(0).strip(),
+                    )
+                )
+    return candidates
+
+
+def _find_narrative_candidates(text: str) -> List[MetricCandidate]:
+    candidates: List[MetricCandidate] = []
+    for metric, pattern in NARRATIVE_PATTERNS.items():
+        for match in pattern.finditer(text):
+            value = _parse_number(match.group("value"))
+            if value is None:
+                continue
+            candidates.append(
+                MetricCandidate(
+                    metric=metric,
+                    value=value,
+                    unit="persons",
+                    layer="narrative",
+                    matched_phrase=match.group(0).strip(),
+                )
+            )
+    return candidates
+
+
+def _gather_candidates(text: str, country_names: Dict[str, str]) -> List[MetricCandidate]:
+    combined = []
+    combined.extend(_find_table_candidates(text, country_names))
+    combined.extend(_find_infographic_candidates(text))
+    combined.extend(_find_narrative_candidates(text))
+    return combined
+
+
+def _choose_best_candidates(candidates: List[MetricCandidate]) -> Dict[Tuple[Optional[str], str], MetricCandidate]:
+    best: Dict[Tuple[Optional[str], str], MetricCandidate] = {}
+    for candidate in candidates:
+        key = (candidate.country_iso3, candidate.metric)
+        current = best.get(key)
+        if current is None:
+            best[key] = candidate
+            continue
+        if LAYER_PRIORITY[candidate.layer] < LAYER_PRIORITY.get(current.layer, 99):
+            best[key] = candidate
+    return best
+
+
+def _apply_household_conversions(
+    best: Dict[Tuple[Optional[str], str], MetricCandidate],
+    iso_list: List[str],
+) -> None:
+    if not best:
+        return
+    for key, candidate in list(best.items()):
+        metric = candidate.metric
+        if metric not in HOUSEHOLD_TO_PEOPLE:
+            continue
+        target_metric = HOUSEHOLD_TO_PEOPLE[metric]
+        iso = candidate.country_iso3
+        if (iso, target_metric) in best:
+            continue
+        if iso is None:
+            if len(iso_list) != 1:
+                continue
+            iso = iso_list[0]
+        entry = PPH.lookup(iso)
+        derived_value = int(round(candidate.value * entry.people_per_household))
+        best[(iso, target_metric)] = MetricCandidate(
+            metric=target_metric,
+            value=derived_value,
+            unit="persons",
+            layer=candidate.layer,
+            matched_phrase=candidate.matched_phrase,
+            method_value="derived_from_households",
+            method_details=entry.describe(),
+            country_iso3=iso,
+            extraction_meta={"pph": entry.people_per_household},
+        )
+
+
+DATE_FORMATS = [
+    "%d %b %Y",
+    "%d %B %Y",
+    "%d %b %y",
+    "%d %B %y",
+    "%Y-%m-%d",
+    "%Y/%m/%d",
+]
+
+
+def _parse_date_token(token: str) -> Optional[dt.date]:
+    if not token:
+        return None
+    cleaned = _clean_text(token).replace("–", "-").replace("/", "/").strip()
+    cleaned = re.sub(r"(\d)(st|nd|rd|th)", r"\1", cleaned)
+    for fmt in DATE_FORMATS:
+        try:
+            return dt.datetime.strptime(cleaned, fmt).date()
+        except ValueError:
+            continue
+    try:
+        return dt.datetime.fromisoformat(cleaned.replace("Z", "")).date()
+    except Exception:
+        return None
+
+
+def _pick_pdf_dates(text: str, fallback_created: str, fallback_changed: str) -> Tuple[str, str]:
+    coverage_line = re.search(
+        r"(?:reporting|coverage)\s+period:?([^\n]+)", text, flags=re.IGNORECASE
+    )
+    if coverage_line:
+        parts = re.split(r"[–-]", coverage_line.group(1))
+        end_token = parts[-1] if parts else ""
+        end = _parse_date_token(end_token)
+        if end:
+            return end.isoformat(), end.isoformat()
+    report_match = re.search(r"report\s+date[:\s]+([0-9a-zA-Z\s,/-]+)", text, flags=re.IGNORECASE)
+    if report_match:
+        parsed = _parse_date_token(report_match.group(1))
+        if parsed:
+            return parsed.isoformat(), parsed.isoformat()
+    fallback = fallback_created or fallback_changed
+    if fallback:
+        return fallback.split("T")[0], (fallback_changed or fallback).split("T")[0]
+    today = dt.datetime.now(dt.timezone.utc).date()
+    return today.isoformat(), today.isoformat()
+
+
+LEVEL_CACHE_FILE = LEVEL_CACHE / "levels.json"
+_LEVEL_STATE: Optional[Dict[str, Dict[str, Any]]] = None
+
+
+def _load_level_state() -> Dict[str, Dict[str, Any]]:
+    global _LEVEL_STATE
+    if _LEVEL_STATE is not None:
+        return _LEVEL_STATE
+    if LEVEL_CACHE_FILE.exists():
+        try:
+            with LEVEL_CACHE_FILE.open("r", encoding="utf-8") as handle:
+                _LEVEL_STATE = json.load(handle)
+        except Exception:
+            _LEVEL_STATE = {}
+    else:
+        _LEVEL_STATE = {}
+    return _LEVEL_STATE
+
+
+def load_last_level_for_lineage(lineage: str) -> Optional[int]:
+    state = _load_level_state()
+    payload = state.get(lineage)
+    if not payload:
+        return None
+    return int(payload.get("value", 0))
+
+
+def store_level_for_lineage(lineage: str, as_of: str, value: int) -> None:
+    state = _load_level_state()
+    state[lineage] = {"as_of": as_of, "value": int(value)}
+    LEVEL_CACHE.mkdir(parents=True, exist_ok=True)
+    with LEVEL_CACHE_FILE.open("w", encoding="utf-8") as handle:
+        json.dump(state, handle, sort_keys=True)
+
+
+def compute_monthly_delta(lineage: str, level_value: int, as_of: str) -> Tuple[int, Optional[int], bool]:
+    previous = load_last_level_for_lineage(lineage)
+    if previous is None:
+        delta = level_value
+        first = True
+    else:
+        delta = max(level_value - previous, 0)
+        first = False
+    store_level_for_lineage(lineage, as_of, level_value)
+    return delta, previous, first
+
+
+def _canonical_metric(metric: str) -> str:
+    mapping = {
+        "people_in_need": "in_need",
+        "people_affected": "affected",
+        "idps": "displaced",
+    }
+    return mapping.get(metric, metric)
+
+
+def _download_pdf(session: requests.Session, url: str, timeout: float = 30.0) -> bytes:
+    PDF_CACHE.mkdir(parents=True, exist_ok=True)
+    digest = stable_digest([url], length=32, algorithm="sha256")
+    path = PDF_CACHE / f"{digest}.pdf"
+    if path.exists():
+        return path.read_bytes()
+    response = session.get(url, timeout=timeout)
+    response.raise_for_status()
+    content = response.content
+    path.write_bytes(content)
+    return content
+
+
+def build_pdf_rows_for_item(
+    cfg: Dict[str, Any],
+    session: requests.Session,
+    fields: Dict[str, Any],
+    hazard_code: str,
+    hazard_label: str,
+    hazard_class: str,
+    iso_pairs: List[Tuple[str, str]],
+    source_name: str,
+    source_type: str,
+    report_title: str,
+    source_url: str,
+) -> List[List[str]]:
+    if not cfg.get("enable_pdfs", True):
+        return []
+    raw_resources = fields.get("file") or fields.get("files") or []
+    pdf_resources = []
+    for res in raw_resources:
+        mime = (res.get("mime_type") or res.get("mimetype") or res.get("content_type") or "").lower()
+        if "pdf" in mime:
+            pdf_resources.append(res)
+    if not pdf_resources:
+        return []
+    preferred = cfg.get("preferred_pdf_titles", [])
+    best = select_best_pdf(pdf_resources, preferred)
+    if not best:
+        return []
+    pdf_url = best.get("url") or best.get("href")
+    if not pdf_url:
+        return []
+    timeout = float(cfg.get("timeout_seconds", 30))
+    content = _download_pdf(session, pdf_url, timeout=timeout)
+    min_chars = int(cfg.get("min_text_chars_before_ocr", 1500))
+    previous_mode = pdf_text_mod.PDF_TEXT_TEST_MODE
+    if not cfg.get("enable_ocr", True):
+        pdf_text_mod.PDF_TEXT_TEST_MODE = True
+    try:
+        text, text_meta = smart_extract(content, min_chars)
+    finally:
+        pdf_text_mod.PDF_TEXT_TEST_MODE = previous_mode
+    if not text.strip():
+        return []
+
+    country_map = {iso: name for name, iso in iso_pairs}
+    candidates = _gather_candidates(text, country_map)
+    if not candidates:
+        return []
+    best_map = _choose_best_candidates(candidates)
+    _apply_household_conversions(best_map, [iso for _, iso in iso_pairs])
+
+    created = fields.get("date", {}).get("created") or fields.get("date.created") or ""
+    changed = fields.get("date", {}).get("changed") or fields.get("date.changed") or ""
+    as_of, publication = _pick_pdf_dates(text, created or "", changed or "")
+    month = month_start(as_of)
+    month_str = month.isoformat() if month else ""
+
+    rows: List[List[str]] = []
+    pdf_rows: List[List[str]] = []
+    ingested_at = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    for (iso_override, metric_key), candidate in best_map.items():
+        iso3 = iso_override or (iso_pairs[0][1] if len(iso_pairs) == 1 else None)
+        if iso3 is None:
+            # Ambiguous allocation in multi-country report.
+            continue
+        country_name = next((name for name, iso in iso_pairs if iso == iso3), "")
+        canonical_metric = _canonical_metric(metric_key)
+        if canonical_metric not in {"in_need", "affected", "displaced"}:
+            continue
+        lineage = "|".join([iso3, hazard_code, canonical_metric, "reliefweb_pdf"])
+        delta, previous_level, first_observation = compute_monthly_delta(lineage, candidate.value, as_of)
+        method_details = candidate.method_details or f"extracted_from_{candidate.layer}"
+        method_details = f"{method_details}; text_extraction={text_meta.get('method', 'native')}"
+        if first_observation:
+            method_details = f"{method_details}; delta_from_level(first_observation)"
+        definition_text = (
+            f"ReliefWeb PDF extraction ({candidate.layer}) for {canonical_metric}"
+        )
+        event_id = stable_digest(
+            [iso3, hazard_code, canonical_metric, as_of, candidate.value, pdf_url],
+            length=16,
+            algorithm="sha256",
+        )
+        rows.append(
+            [
+                event_id,
+                country_name,
+                iso3,
+                hazard_code,
+                hazard_label,
+                hazard_class,
+                canonical_metric,
+                "new",
+                str(delta),
+                "persons",
+                str(candidate.value),
+                as_of,
+                month_str,
+                publication,
+                source_name,
+                source_type,
+                source_url,
+                pdf_url,
+                report_title,
+                definition_text,
+                "pdf",
+                candidate.method_value,
+                method_details,
+                candidate.layer,
+                candidate.matched_phrase,
+                "2",
+                "med",
+                1,
+                ingested_at,
+            ]
+        )
+    return rows
 
 NUM_RE = re.compile(
     r"\b(?:about|approx\.?|around)?\s*([0-9][0-9., ]{0,15})(?:\s*(?:people|persons|individuals))?\b",
@@ -422,7 +1109,7 @@ def make_rows() -> Tuple[List[List[str]], Dict[str, Any]]:
         )
         if data is None:
             challenge_tracker["mode"] = mode
-            return rows, challenge_tracker
+            return rows, pdf_rows, challenge_tracker
         if mode == "get":
             mode_used = "get"
         total = total or data.get("totalCount", 0)
@@ -498,6 +1185,22 @@ def make_rows() -> Tuple[List[List[str]], Dict[str, Any]]:
                     ]
                 )
 
+            pdf_rows.extend(
+                build_pdf_rows_for_item(
+                    cfg,
+                    session,
+                    fields,
+                    hazard_code,
+                    hazard_label,
+                    hazard_class,
+                    iso_pairs,
+                    source_name or "OCHA",
+                    map_source_type(report_type, cfg),
+                    doc_title,
+                    source_url,
+                )
+            )
+
         offset += len(items)
         if offset >= total:
             break
@@ -505,7 +1208,7 @@ def make_rows() -> Tuple[List[List[str]], Dict[str, Any]]:
 
     challenge_tracker["mode"] = mode_used
 
-    return rows, challenge_tracker
+    return rows, pdf_rows, challenge_tracker
 
 
 def main() -> None:
@@ -513,14 +1216,17 @@ def main() -> None:
         print("ReliefWeb connector skipped due to RESOLVER_SKIP_RELIEFWEB=1")
         STAGING.mkdir(parents=True, exist_ok=True)
         output = STAGING / "reliefweb.csv"
-        pd.DataFrame(columns=COLUMNS).to_csv(output, index=False)
-        print("[reliefweb] rows=0 challenged=0 mode=empty")
+        ensure_headers(output, COLUMNS)
+        ensure_headers(PDF_OUTPUT, PDF_COLUMNS)
+        ensure_manifest_for_csv(output, source_id="reliefweb_api")
+        ensure_manifest_for_csv(PDF_OUTPUT, source_id="reliefweb_pdf")
+        print("[reliefweb] rows=0 challenged=0 mode=empty pdf_rows=0")
         return
 
     STAGING.mkdir(parents=True, exist_ok=True)
     output = STAGING / "reliefweb.csv"
     try:
-        rows, challenge_tracker = make_rows()
+        rows, pdf_rows, challenge_tracker = make_rows()
     except RuntimeError as exc:
         message = str(exc)
         if "WAF_CHALLENGE" in message:
@@ -528,26 +1234,43 @@ def main() -> None:
                 "ReliefWeb blocked by AWS WAF challenge (202 + x-amzn-waf-action=challenge). "
                 "Writing empty CSV and continuing."
             )
-            pd.DataFrame(columns=COLUMNS).to_csv(output, index=False)
-            print("[reliefweb] rows=0 challenged=0 mode=empty")
+            ensure_headers(output, COLUMNS)
+            ensure_headers(PDF_OUTPUT, PDF_COLUMNS)
+            ensure_manifest_for_csv(output, source_id="reliefweb_api")
+            ensure_manifest_for_csv(PDF_OUTPUT, source_id="reliefweb_pdf")
+            print("[reliefweb] rows=0 challenged=0 mode=empty pdf_rows=0")
             return
         raise
     challenged = int(challenge_tracker.get("count", 0))
     mode = challenge_tracker.get("mode", "post")
     if challenge_tracker.get("persisted"):
         print("ReliefWeb WAF challenge persisted; writing empty CSV this run")
-        pd.DataFrame(columns=COLUMNS).to_csv(output, index=False)
-        print(f"[reliefweb] rows=0 challenged={challenged} mode=empty")
+        ensure_headers(output, COLUMNS)
+        ensure_headers(PDF_OUTPUT, PDF_COLUMNS)
+        ensure_manifest_for_csv(output, source_id="reliefweb_api")
+        ensure_manifest_for_csv(PDF_OUTPUT, source_id="reliefweb_pdf")
+        print(f"[reliefweb] rows=0 challenged={challenged} mode=empty pdf_rows=0")
         return
 
     if not rows:
-        pd.DataFrame(columns=COLUMNS).to_csv(output, index=False)
+        ensure_headers(output, COLUMNS)
         print(f"[reliefweb] rows=0 challenged={challenged} mode={mode}")
-        return
+    else:
+        df = pd.DataFrame(rows, columns=COLUMNS)
+        df.to_csv(output, index=False)
+        print(f"[reliefweb] rows={len(df)} challenged={challenged} mode={mode}")
 
-    df = pd.DataFrame(rows, columns=COLUMNS)
-    df.to_csv(output, index=False)
-    print(f"[reliefweb] rows={len(df)} challenged={challenged} mode={mode}")
+    if not pdf_rows:
+        ensure_headers(PDF_OUTPUT, PDF_COLUMNS)
+        pdf_count = 0
+    else:
+        pdf_df = pd.DataFrame(pdf_rows, columns=PDF_COLUMNS)
+        pdf_df.to_csv(PDF_OUTPUT, index=False)
+        pdf_count = len(pdf_df)
+
+    ensure_manifest_for_csv(output, source_id="reliefweb_api")
+    ensure_manifest_for_csv(PDF_OUTPUT, source_id="reliefweb_pdf")
+    print(f"[reliefweb_pdf] rows={pdf_count}")
 
 
 if __name__ == "__main__":

--- a/resolver/reference/avg_household_size.csv
+++ b/resolver/reference/avg_household_size.csv
@@ -1,0 +1,6 @@
+iso3,people_per_household,source,year,notes
+AFG,6.80,"UN DESA Household Size Database",2022,"Illustrative starter value"
+ETH,4.60,"UN DESA Household Size Database",2022,"Illustrative starter value"
+HTI,4.30,"UN DESA Household Size Database",2022,"Illustrative starter value"
+NER,5.80,"UN DESA Household Size Database",2022,"Illustrative starter value"
+PHL,4.20,"Philippines PSA Family Income and Expenditure Survey",2021,"Illustrative starter value"

--- a/resolver/reference/overrides/avg_household_size_overrides.yml
+++ b/resolver/reference/overrides/avg_household_size_overrides.yml
@@ -1,0 +1,7 @@
+overrides:
+  # Example:
+  # USA:
+  #   people_per_household: 2.60
+  #   source: "Custom Override"
+  #   year: 2024
+  #   notes: "Project specific override"

--- a/resolver/tests/README.md
+++ b/resolver/tests/README.md
@@ -68,3 +68,10 @@ the schema needs to change.
 ### Hermetic connector tests
 Header tests set `RESOLVER_SKIP_IFRCGO=1` and `RESOLVER_SKIP_RELIEFWEB=1` so no network is required.
 Each connector must still produce a CSV with the canonical header (even if empty).
+
+### ReliefWeb PDF tests
+
+`resolver/tests/ingestion/test_reliefweb_pdf.py` monkeypatches the PDF text
+extraction helper so we can exercise parsing, precedence, and delta logic using
+plain strings.  No binary fixtures are required; see
+`resolver/tests/fixtures/reliefweb_pdfs/README.md` for details.

--- a/resolver/tests/fixtures/reliefweb_pdfs/README.md
+++ b/resolver/tests/fixtures/reliefweb_pdfs/README.md
@@ -1,0 +1,7 @@
+# ReliefWeb PDF fixtures
+
+Binary PDFs are deliberately **not** stored in the repository.  The ReliefWeb
+PDF ingestion tests monkeypatch `_pdf_text.smart_extract` to return deterministic
+fixture strings so we can exercise parsing behaviour without bundling large
+assets.  When adding new scenarios, keep the test strings in the test module or
+store short text snippets in this folder.

--- a/resolver/tests/ingestion/test_reliefweb_pdf.py
+++ b/resolver/tests/ingestion/test_reliefweb_pdf.py
@@ -1,0 +1,427 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in __import__("sys").path:
+    __import__("sys").path.insert(0, str(ROOT))
+
+from resolver.ingestion import reliefweb_client as rw
+
+
+def _base_cfg() -> Dict[str, object]:
+    return {
+        "enable_pdfs": True,
+        "enable_ocr": True,
+        "min_text_chars_before_ocr": 1500,
+        "preferred_pdf_titles": ["situation report", "flash update", "key figures"],
+        "timeout_seconds": 5,
+    }
+
+
+def _base_fields(pdf_url: str) -> Dict[str, object]:
+    return {
+        "file": [
+            {
+                "mime_type": "application/pdf",
+                "url": pdf_url,
+                "name": "Situation Report",
+                "date": {"created": "2025-08-01T00:00:00Z"},
+                "page_count": 4,
+            }
+        ],
+        "date": {"created": "2025-08-01T00:00:00Z", "changed": "2025-08-02T00:00:00Z"},
+    }
+
+
+@pytest.fixture(autouse=True)
+def _reset_level_cache(tmp_path, monkeypatch):
+    level_dir = tmp_path / "levels"
+    monkeypatch.setattr(rw, "LEVEL_CACHE", level_dir)
+    monkeypatch.setattr(rw, "LEVEL_CACHE_FILE", level_dir / "levels.json")
+    monkeypatch.setattr(rw, "_LEVEL_STATE", None)
+    level_dir.mkdir(parents=True, exist_ok=True)
+    yield
+
+
+@pytest.fixture
+def _stub_pdf(monkeypatch):
+    monkeypatch.setattr(rw, "_download_pdf", lambda session, url, timeout=30.0: b"stub")
+
+
+def _rows_to_dicts(rows: List[List[str]]) -> List[Dict[str, str]]:
+    return [dict(zip(rw.PDF_COLUMNS, row)) for row in rows]
+
+
+def test_pdf_selection_heuristic():
+    resources = [
+        {
+            "name": "Generic attachment",
+            "date": {"created": "2025-01-01T00:00:00Z"},
+            "page_count": 2,
+        },
+        {
+            "name": "Somalia Situation Report",
+            "date": {"created": "2025-02-01T00:00:00Z"},
+            "page_count": 1,
+        },
+    ]
+    preferred = ["flash update", "situation report"]
+    best = rw.select_best_pdf(resources, preferred)
+    assert best["name"] == "Somalia Situation Report"
+
+
+def test_table_precedence_over_narrative(monkeypatch, _stub_pdf):
+    cfg = _base_cfg()
+    fields = _base_fields("https://example.org/table.pdf")
+    text = """
+Country | People in Need | People Affected
+Somalia | 120,000 | 90,000
+
+The report notes that 50,000 people in need remain in hard-to-reach areas.
+"""
+    monkeypatch.setattr(rw, "smart_extract", lambda content, min_chars: (text, {"method": "native"}))
+    rows = rw.build_pdf_rows_for_item(
+        cfg,
+        session=None,  # unused by stub download
+        fields=fields,
+        hazard_code="FL",
+        hazard_label="Flood",
+        hazard_class="natural",
+        iso_pairs=[("Somalia", "SOM")],
+        source_name="OCHA",
+        source_type="sitrep",
+        report_title="Somalia SitRep",
+        source_url="https://reliefweb.int/report/123",
+    )
+    data = _rows_to_dicts(rows)
+    assert data[0]["value_level"] == "120000"
+    assert data[0]["value"] == "120000"
+    assert data[0]["extraction_layer"] == "table"
+    assert data[0]["method_value"] == "reported"
+
+
+def test_infographic_precedence_over_narrative(monkeypatch, _stub_pdf):
+    cfg = _base_cfg()
+    fields = _base_fields("https://example.org/infographic.pdf")
+    text = """
+KEY FIGURES
+People Affected: 45k individuals
+
+Narrative states 10,000 people affected in rural zones.
+"""
+    monkeypatch.setattr(rw, "smart_extract", lambda content, min_chars: (text, {"method": "hybrid"}))
+    rows = rw.build_pdf_rows_for_item(
+        cfg,
+        session=None,
+        fields=fields,
+        hazard_code="FL",
+        hazard_label="Flood",
+        hazard_class="natural",
+        iso_pairs=[("Somalia", "SOM")],
+        source_name="OCHA",
+        source_type="sitrep",
+        report_title="Somalia Flash Update",
+        source_url="https://reliefweb.int/report/456",
+    )
+    data = _rows_to_dicts(rows)
+    assert data[0]["value_level"] == "45000"
+    assert data[0]["extraction_layer"] == "infographic"
+    assert "text_extraction=hybrid" in data[0]["method_details"]
+
+
+def test_household_to_people_conversion(monkeypatch, _stub_pdf):
+    cfg = _base_cfg()
+    fields = _base_fields("https://example.org/hh.pdf")
+    text = """
+Country | Households Affected
+Somalia | 1,000
+"""
+    monkeypatch.setattr(rw, "smart_extract", lambda *_: (text, {"method": "native"}))
+    rw.PPH._loaded = True
+    rw.PPH._table = {"SOM": rw.PPHEntry("SOM", 5.2, "Survey", 2024)}
+    rows = rw.build_pdf_rows_for_item(
+        cfg,
+        session=None,
+        fields=fields,
+        hazard_code="FL",
+        hazard_label="Flood",
+        hazard_class="natural",
+        iso_pairs=[("Somalia", "SOM")],
+        source_name="OCHA",
+        source_type="sitrep",
+        report_title="Somalia SitRep",
+        source_url="https://reliefweb.int/report/789",
+    )
+    data = _rows_to_dicts(rows)
+    assert data[0]["value_level"] == str(int(1000 * 5.2))
+    assert data[0]["method_value"] == "derived_from_households"
+    assert "PPH=5.20" in data[0]["method_details"]
+    rw.PPH._loaded = False
+    rw.PPH._table = {}
+
+
+def test_date_picking_coverage_period(monkeypatch, _stub_pdf):
+    cfg = _base_cfg()
+    fields = _base_fields("https://example.org/date.pdf")
+    text = """
+Reporting period: 01–31 Aug 2025
+Country | People in Need
+Somalia | 1,234
+"""
+    monkeypatch.setattr(rw, "smart_extract", lambda *_: (text, {"method": "native"}))
+    rows = rw.build_pdf_rows_for_item(
+        cfg,
+        session=None,
+        fields=fields,
+        hazard_code="FL",
+        hazard_label="Flood",
+        hazard_class="natural",
+        iso_pairs=[("Somalia", "SOM")],
+        source_name="OCHA",
+        source_type="sitrep",
+        report_title="Somalia SitRep",
+        source_url="https://reliefweb.int/report/101",
+    )
+    data = _rows_to_dicts(rows)
+    assert data[0]["as_of_date"] == "2025-08-31"
+
+
+def test_multi_country_split(monkeypatch, _stub_pdf):
+    cfg = _base_cfg()
+    fields = _base_fields("https://example.org/multi.pdf")
+    text = """
+Country | People in Need
+Somalia | 1,000
+Kenya | 2,000
+
+Combined statement: 3,000 people in need across Somalia and Kenya.
+"""
+    monkeypatch.setattr(rw, "smart_extract", lambda *_: (text, {"method": "native"}))
+    rows = rw.build_pdf_rows_for_item(
+        cfg,
+        session=None,
+        fields=fields,
+        hazard_code="FL",
+        hazard_label="Flood",
+        hazard_class="natural",
+        iso_pairs=[("Somalia", "SOM"), ("Kenya", "KEN")],
+        source_name="OCHA",
+        source_type="sitrep",
+        report_title="Regional SitRep",
+        source_url="https://reliefweb.int/report/202",
+    )
+    data = _rows_to_dicts(rows)
+    assert {row["iso3"]: row["value_level"] for row in data} == {"SOM": "1000", "KEN": "2000"}
+
+    # Ambiguous aggregate only should yield no rows.
+    text_ambiguous = "Overall, 5,000 people in need across Somalia and Kenya."
+    monkeypatch.setattr(rw, "smart_extract", lambda *_: (text_ambiguous, {"method": "native"}))
+    ambiguous_rows = rw.build_pdf_rows_for_item(
+        cfg,
+        session=None,
+        fields=fields,
+        hazard_code="FL",
+        hazard_label="Flood",
+        hazard_class="natural",
+        iso_pairs=[("Somalia", "SOM"), ("Kenya", "KEN")],
+        source_name="OCHA",
+        source_type="sitrep",
+        report_title="Regional SitRep",
+        source_url="https://reliefweb.int/report/202",
+    )
+    assert ambiguous_rows == []
+
+
+def test_event_id_deterministic(monkeypatch, _stub_pdf):
+    cfg = _base_cfg()
+    fields = _base_fields("https://example.org/event.pdf")
+    text = """
+Country | People in Need
+Somalia | 2,222
+"""
+
+    monkeypatch.setattr(rw, "smart_extract", lambda *_: (text, {"method": "native"}))
+
+    rows_first = rw.build_pdf_rows_for_item(
+        cfg,
+        session=None,
+        fields=fields,
+        hazard_code="FL",
+        hazard_label="Flood",
+        hazard_class="natural",
+        iso_pairs=[("Somalia", "SOM")],
+        source_name="OCHA",
+        source_type="sitrep",
+        report_title="Somalia SitRep",
+        source_url="https://reliefweb.int/report/303",
+    )
+
+    # Reset cache to simulate a fresh run with identical inputs.
+    rw._LEVEL_STATE = None
+    if rw.LEVEL_CACHE_FILE.exists():
+        rw.LEVEL_CACHE_FILE.unlink()
+
+    rows_second = rw.build_pdf_rows_for_item(
+        cfg,
+        session=None,
+        fields=fields,
+        hazard_code="FL",
+        hazard_label="Flood",
+        hazard_class="natural",
+        iso_pairs=[("Somalia", "SOM")],
+        source_name="OCHA",
+        source_type="sitrep",
+        report_title="Somalia SitRep",
+        source_url="https://reliefweb.int/report/303",
+    )
+
+    first_id = rows_first[0][0]
+    second_id = rows_second[0][0]
+    assert first_id == second_id
+
+
+def test_delta_computation(monkeypatch, _stub_pdf):
+    cfg = _base_cfg()
+    fields = _base_fields("https://example.org/delta.pdf")
+
+    text_july = """
+Reporting period: 01–31 Jul 2025
+Country | People in Need
+Somalia | 1,000
+"""
+    text_aug = """
+Reporting period: 01–31 Aug 2025
+Country | People in Need
+Somalia | 1,500
+"""
+
+    monkeypatch.setattr(rw, "smart_extract", lambda *_: (text_july, {"method": "native"}))
+    july_rows = rw.build_pdf_rows_for_item(
+        cfg,
+        session=None,
+        fields=fields,
+        hazard_code="FL",
+        hazard_label="Flood",
+        hazard_class="natural",
+        iso_pairs=[("Somalia", "SOM")],
+        source_name="OCHA",
+        source_type="sitrep",
+        report_title="Somalia July SitRep",
+        source_url="https://reliefweb.int/report/404",
+    )
+    monkeypatch.setattr(rw, "smart_extract", lambda *_: (text_aug, {"method": "native"}))
+    aug_rows = rw.build_pdf_rows_for_item(
+        cfg,
+        session=None,
+        fields=fields,
+        hazard_code="FL",
+        hazard_label="Flood",
+        hazard_class="natural",
+        iso_pairs=[("Somalia", "SOM")],
+        source_name="OCHA",
+        source_type="sitrep",
+        report_title="Somalia Aug SitRep",
+        source_url="https://reliefweb.int/report/405",
+    )
+    july = _rows_to_dicts(july_rows)[0]
+    aug = _rows_to_dicts(aug_rows)[0]
+    assert july["value"] == "1000"
+    assert aug["value"] == "500"
+
+
+def test_ocr_threshold_trigger(monkeypatch, _stub_pdf):
+    cfg = _base_cfg()
+    cfg["enable_ocr"] = True
+    fields = _base_fields("https://example.org/ocr.pdf")
+    text = """
+KEY FIGURES
+People in Need: 10k
+"""
+
+    def fake_extract(content, min_chars):
+        assert min_chars == cfg["min_text_chars_before_ocr"]
+        return text, {"method": "hybrid"}
+
+    monkeypatch.setattr(rw, "smart_extract", fake_extract)
+    rows = rw.build_pdf_rows_for_item(
+        cfg,
+        session=None,
+        fields=fields,
+        hazard_code="FL",
+        hazard_label="Flood",
+        hazard_class="natural",
+        iso_pairs=[("Somalia", "SOM")],
+        source_name="OCHA",
+        source_type="sitrep",
+        report_title="Somalia OCR SitRep",
+        source_url="https://reliefweb.int/report/406",
+    )
+    data = _rows_to_dicts(rows)
+    assert "text_extraction=hybrid" in data[0]["method_details"]
+
+
+def test_manifest_and_tier(tmp_path, monkeypatch):
+    out_dir = tmp_path / "staging"
+    out_dir.mkdir()
+    monkeypatch.setattr(rw, "STAGING", out_dir)
+    monkeypatch.setattr(rw, "PDF_OUTPUT", out_dir / "reliefweb_pdf.csv")
+    monkeypatch.setattr(rw, "PDF_CACHE", out_dir / "cache")
+    monkeypatch.setattr(rw, "LEVEL_CACHE", out_dir / "levels")
+    monkeypatch.setattr(rw, "LEVEL_CACHE_FILE", out_dir / "levels" / "levels.json")
+    monkeypatch.setattr(rw, "_LEVEL_STATE", None)
+
+    def fake_make_rows():
+        api_rows = []
+        pdf_row = [
+            "event-1",
+            "Somalia",
+            "SOM",
+            "FL",
+            "Flood",
+            "natural",
+            "in_need",
+            "new",
+            "100",
+            "persons",
+            "100",
+            "2025-08-31",
+            "2025-08-01",
+            "2025-08-31",
+            "OCHA",
+            "sitrep",
+            "https://reliefweb.int/report/manifest",
+            "https://reliefweb.int/resource/manifest.pdf",
+            "Somalia SitRep",
+            "definition",
+            "pdf",
+            "reported",
+            "extracted_from_table; text_extraction=native",
+            "table",
+            "Somalia | 100",
+            "2",
+            "med",
+            1,
+            "2025-09-01T00:00:00Z",
+        ]
+        tracker = {"count": 0, "mode": "post", "persisted": False}
+        return api_rows, [pdf_row], tracker
+
+    monkeypatch.setattr(rw, "make_rows", fake_make_rows)
+    monkeypatch.delenv("RESOLVER_SKIP_RELIEFWEB", raising=False)
+    rw.main()
+
+    pdf_path = out_dir / "reliefweb_pdf.csv"
+    assert pdf_path.exists()
+    pdf_df = pd.read_csv(pdf_path, dtype=str)
+    assert pdf_df["tier"].tolist() == ["2"]
+
+    manifest_path = pdf_path.with_suffix(".csv.meta.json")
+    assert manifest_path.exists()
+    payload = json.loads(manifest_path.read_text())
+    assert payload["row_count"] == 1

--- a/resolver/tools/precedence_config.yml
+++ b/resolver/tools/precedence_config.yml
@@ -3,7 +3,7 @@ metric_preference: [in_need, affected]   # PIN first, else PA
 tiers:
   - ["unhcr_api", "unhcr_odp", "ifrc_go", "who", "ipc", "wfp_mvam", "dtm", "acled"]
   - ["hdx", "emdat", "gdacs"]
-  - ["reliefweb", "media"]
+  - ["reliefweb", "reliefweb_pdf", "media"]  # reliefweb_pdf stays Tier 2 (same as ReliefWeb API)
 source_precedence:                       # highest → lowest (legacy policy tiers)
   - inter_agency_plan
   - ifrc_or_gov_sitrep


### PR DESCRIPTION
## Summary
- add a PDF text extraction helper that supports native parsing, OCR fallback, and test hooks
- extend the ReliefWeb connector to download and parse PDFs, convert household figures via PPH, and emit tier-2 monthly deltas with manifests
- document the PDF pipeline, add reference PPH tables, and cover behaviour with dedicated tests and fixtures

## Testing
- pytest -q resolver/tests/ingestion/test_reliefweb_pdf.py
- pytest -q resolver/tests -k reliefweb_pdf


------
https://chatgpt.com/codex/tasks/task_e_68e33ea3a9c8832cae3de5610b623237