### PR TITLE
Add resolver pipeline documentation and ReliefWeb PDF runbook

### DIFF
--- a/.github/workflows/resolver-ci.yml
+++ b/.github/workflows/resolver-ci.yml
@@ -45,3 +45,37 @@ jobs:
       - name: ReliefWeb PDF Unit Tests (mocked extractors)
         run: |
           pytest -q resolver/tests/ingestion/test_reliefweb_pdf.py
+      - name: Docs Link Check (non-blocking)
+        continue-on-error: true
+        run: |
+          python - <<'PY'
+import pathlib
+import re
+import sys
+
+root = pathlib.Path('.').resolve()
+md_files = [p for p in root.glob('resolver/**/*.md')]
+pattern = re.compile(r'\[[^\]]+\]\(([^)]+)\)')
+broken = []
+
+for md in md_files:
+    text = md.read_text(encoding='utf-8')
+    for match in pattern.finditer(text):
+        link = match.group(1)
+        if link.startswith(('http://', 'https://', 'mailto:')):
+            continue
+        if link.startswith('#') or link.startswith('?'):
+            continue
+        target_str = link.split('#', 1)[0]
+        target_path = (md.parent / target_str).resolve()
+        if not target_path.exists():
+            broken.append(f"{md.relative_to(root)} -> {link}")
+
+if broken:
+    print('Broken Markdown links found:')
+    for item in broken:
+        print(f" - {item}")
+    sys.exit(1)
+else:
+    print('No broken intra-repo Markdown links found.')
+PY

--- a/resolver/docs/connectors_catalog.md
+++ b/resolver/docs/connectors_catalog.md
@@ -1,0 +1,31 @@
+# Connectors Catalog
+
+This catalog documents the primary Resolver connectors, their configuration sources, entry points, and staging outputs. All connectors emit CSVs with the canonical staging header documented in [Data contracts](data_contracts.md).
+
+| Connector | Config | Entrypoint | Output CSV | Notes |
+|---|---|---|---|---|
+| ACLED | [`ingestion/config/acled.yml`](../ingestion/config/acled.yml) | [`ingestion/acled_client.py`](../ingestion/acled_client.py) | `staging/acled.csv` | Conflict events aggregated to humanitarian impact metrics. |
+| DTM | [`ingestion/config/dtm.yml`](../ingestion/config/dtm.yml) | [`ingestion/dtm_client.py`](../ingestion/dtm_client.py) | `staging/dtm.csv` | Pulls displacement monitors, normalises ISO3 and hazard taxonomy. |
+| EMDAT | [`ingestion/config/emdat.yml`](../ingestion/config/emdat.yml) | [`ingestion/emdat_client.py`](../ingestion/emdat_client.py) | `staging/emdat.csv` | Disaster loss archive; often used for historical baselines. |
+| FEWS NET | (stubbed) | [`ingestion/fews_stub.py`](../ingestion/fews_stub.py) | `staging/fews.csv` | Stub produces canonical header for offline smoke tests. |
+| GDACS | [`ingestion/config/gdacs.yml`](../ingestion/config/gdacs.yml) | [`ingestion/gdacs_client.py`](../ingestion/gdacs_client.py) | `staging/gdacs.csv` | Global Disaster Alert and Coordination System feeds for rapid-onset events. |
+| HDX | [`ingestion/config/hdx.yml`](../ingestion/config/hdx.yml) | [`ingestion/hdx_client.py`](../ingestion/hdx_client.py) | `staging/hdx.csv` | Fetches curated humanitarian indicators from HDX datasets. |
+| IFRC GO | [`ingestion/config/ifrc_go.yml`](../ingestion/config/ifrc_go.yml) | [`ingestion/ifrc_go_client.py`](../ingestion/ifrc_go_client.py) | `staging/ifrc_go.csv` | Handles GO API pagination and report metadata quirks. |
+| IPC | [`ingestion/config/ipc.yml`](../ingestion/config/ipc.yml) | [`ingestion/ipc_client.py`](../ingestion/ipc_client.py) | `staging/ipc.csv` | Integrated Food Security Phase Classification (IPC/CH) feed. |
+| UNHCR (Population) | [`ingestion/config/unhcr.yml`](../ingestion/config/unhcr.yml) | [`ingestion/unhcr_client.py`](../ingestion/unhcr_client.py) | `staging/unhcr.csv` | Global population statistics, includes asylum/refugee cohorts. |
+| UNHCR ODP | [`ingestion/config/unhcr_odp.yml`](../ingestion/config/unhcr_odp.yml) | [`ingestion/unhcr_odp_client.py`](../ingestion/unhcr_odp_client.py) | `staging/unhcr_odp.csv` | Operational Data Portal situational reports. |
+| WFP mVAM | [`ingestion/config/wfp_mvam.yml`](../ingestion/config/wfp_mvam.yml) | [`ingestion/wfp_mvam_client.py`](../ingestion/wfp_mvam_client.py) | `staging/wfp_mvam.csv` | Mobile Vulnerability Analysis and Mapping indicators. |
+| WHO PHE | [`ingestion/config/who_phe.yml`](../ingestion/config/who_phe.yml) | [`ingestion/who_phe_client.py`](../ingestion/who_phe_client.py) | `staging/who_phe.csv` | Public health emergency surveillance, includes case counts. |
+| WorldPop | [`ingestion/config/worldpop.yml`](../ingestion/config/worldpop.yml) | [`ingestion/worldpop_client.py`](../ingestion/worldpop_client.py) | `staging/worldpop.csv` | Population denominators for coverage checks. |
+| ReliefWeb (API) | [`ingestion/config/reliefweb.yml`](../ingestion/config/reliefweb.yml) | [`ingestion/reliefweb_client.py`](../ingestion/reliefweb_client.py) | `staging/reliefweb.csv` | Handles WAF 202 challenges; header-only output when blocked. |
+| ReliefWeb (PDF) | [`ingestion/config/reliefweb.yml`](../ingestion/config/reliefweb.yml) (PDF toggles) | [`ingestion/reliefweb_client.py`](../ingestion/reliefweb_client.py) | `staging/reliefweb_pdf.csv` | Scores & downloads PDFs, native parsing then OCR fallback, HH→people conversion, tier-2 monthly deltas. |
+
+### Shared conventions
+
+Across staging outputs the following columns are standard:
+
+- `as_of`, `source`, `event_id`, `country_iso3`, `month`, `hazard_type`, `metric`, `value`
+- Provenance fields such as `source_type`, `source_url`, and `definition_text`
+- Tier metadata (`tier`, `confidence`) used by the precedence engine
+
+Refer to the [data contracts](data_contracts.md) and generated [SCHEMAS.md](../../SCHEMAS.md) for exhaustive field definitions.

--- a/resolver/docs/data_contracts.md
+++ b/resolver/docs/data_contracts.md
@@ -1,0 +1,40 @@
+# Data Contracts
+
+Resolver normalises staging inputs and exported facts into a shared schema. This document highlights the canonical columns, ReliefWeb PDF additions, and pointers to the authoritative schema definitions.
+
+## Canonical staging columns
+
+All staging CSVs under `resolver/staging/` adhere to [`resolver/tools/schema.yml`](../tools/schema.yml). The generated [SCHEMAS.md](../../SCHEMAS.md) file provides column-level descriptions. Core columns include:
+
+- Identifiers: `event_id`, `source`, `source_event_id`, `country_iso3`, `hazard_code`, `metric`
+- Temporal fields: `as_of`, `month`, `publication_date`, `ingested_at`
+- Figures: `value` (monthly new), `value_level` (optional stock), `unit`
+- Provenance: `source_type`, `source_url`, `definition_text`, `method`, `method_value`
+- Precedence hints: `tier`, `confidence`, `revision`
+
+## ReliefWeb PDF staging contract
+
+`resolver/staging/reliefweb_pdf.csv` extends the base schema with additional metadata needed for auditability:
+
+- `pph_used` — numeric people-per-household multiplier applied when converting households → people
+- `extraction_method` — `pdf_native` or `ocr` indicating which text layer produced the metric
+- `pdf_score` — selector score used to pick the attachment
+- `matched_phrase` — snippet showing the parsed metric context
+- `series_semantics` — fixed to `new` to denote monthly deltas already computed in the connector
+- `tier` — set to `2` so precedence can prioritise higher-tier sources when present
+
+The ReliefWeb PDF manifest (`resolver/staging/reliefweb_pdf.csv.meta.json`) mirrors the standard manifest structure with additional keys for attachment `artifact_sha256`, selector `score`, and `extraction_method`.
+
+## Facts exports
+
+[`resolver/tools/export_facts.py`](../tools/export_facts.py) consolidates staging files into `resolver/exports/facts.csv`. Facts retain the staging fields and add:
+
+- `ym` — `YYYY-MM` derived from `as_of` for monthly joins
+- `series` — `new` or `stock` with `new` being the default for PIN/PA metrics
+- `precedence_notes` — populated after review to document overrides
+
+All People in Need (PIN) and People Affected (PA) figures in facts are stored as **monthly "new" values**. Stock totals are differenced during export or inside connectors (ReliefWeb PDF) before reaching precedence.
+
+## People-per-household reference
+
+Household conversions use `resolver/reference/avg_household_size.csv` as the base table. Overrides live in `resolver/reference/overrides/avg_household_size_overrides.yml`. A custom path can be supplied with `RELIEFWEB_PPH_OVERRIDE_PATH` when testing alternative datasets.

--- a/resolver/docs/operations.md
+++ b/resolver/docs/operations.md
@@ -1,0 +1,62 @@
+# Operations Run Book
+
+This run book covers the main resolver workflows, including the ReliefWeb PDF branch. It is designed for engineers and analysts running the pipeline locally or in CI.
+
+## Quick start
+
+1. **Ingest connectors (offline stubs):**
+   ```bash
+   python resolver/ingestion/run_all_stubs.py --retries 2
+   ```
+2. **Validate staging schemas:**
+   ```bash
+   pytest -q resolver/tests/test_staging_schema_all.py
+   ```
+3. **Export and validate facts:**
+   ```bash
+   python resolver/tools/export_facts.py --in resolver/staging --out resolver/exports
+   python resolver/tools/validate_facts.py --facts resolver/exports/facts.csv
+   ```
+4. **Run precedence & deltas (optional for analytics):**
+   ```bash
+   python resolver/tools/precedence_engine.py --facts resolver/exports/facts.csv --cutoff YYYY-MM-30
+   python resolver/tools/make_deltas.py --resolved resolver/exports/resolved.csv --out resolver/exports/deltas.csv
+   ```
+5. **Freeze a snapshot:**
+   ```bash
+   python resolver/tools/freeze_snapshot.py --facts resolver/exports/facts.csv --month YYYY-MM
+   ```
+
+## ReliefWeb PDF local runs
+
+The PDF branch can be exercised without network access by enabling the feature flags and relying on mocked text extraction:
+
+```bash
+RELIEFWEB_ENABLE_PDF=1 \
+RELIEFWEB_PDF_ALLOW_NETWORK=0 \
+RELIEFWEB_PDF_ENABLE_OCR=0 \
+python resolver/ingestion/reliefweb_client.py
+```
+
+To run the mocked extractor tests:
+
+```bash
+pytest -q resolver/tests/ingestion/test_reliefweb_pdf.py
+```
+
+### Feature toggles
+
+- `RELIEFWEB_ENABLE_PDF=1|0` — enable or disable the PDF branch entirely
+- `RELIEFWEB_PDF_ENABLE_OCR=1|0` — allow OCR fallback when native text is sparse
+- `RELIEFWEB_PDF_ALLOW_NETWORK=1|0` — control attachment downloads (CI keeps this at `0`)
+- `RELIEFWEB_PPH_OVERRIDE_PATH=/path/to/pph.csv` — optional CSV for household overrides
+
+## Logs and observability
+
+- Ingestion writes plain text and JSONL logs to `resolver/logs/ingestion/` by default.
+- Override destinations with `RUNNER_LOG_DIR=/tmp/resolver-logs`.
+- Set verbosity via `RUNNER_LOG_LEVEL=DEBUG` and format via `RUNNER_LOG_FORMAT=json`.
+
+## Continuous integration
+
+The `resolver-ci` workflow executes offline smoke tests plus the ReliefWeb PDF unit suite. When the optional Markdown link checker is enabled it runs after the tests and reports broken intra-repo links in the job logs without failing the build.

--- a/resolver/docs/pipeline_overview.md
+++ b/resolver/docs/pipeline_overview.md
@@ -1,0 +1,47 @@
+# Resolver Pipeline Overview
+
+This page provides a guided tour of the Resolver data pipeline from the first connector call to the publication of exports and frozen monthly snapshots. It is intended for contributors who need to understand how staging inputs, validation, precedence, and ReliefWeb PDF parsing fit together.
+
+```mermaid
+flowchart LR
+  A[Connectors (ACLED, DTM, IPC, IFRC GO, UNHCR, WFP mVAM, WHO PHE, HDX, GDACS, WorldPop, ReliefWeb)]
+  A --> B[Staging CSVs: resolver/staging/*.csv]
+  subgraph ReliefWeb PDF Branch
+    A --> A1[ReliefWeb PDF Selector]
+    A1 --> A2[PDF Text Extraction (native→OCR fallback)]
+    A2 --> A3[Metric Parsing + HH→People Conversion]
+    A3 --> A4[Tier-2 Monthly Deltas]
+    A4 --> B_pdf[staging/reliefweb_pdf.csv]
+  end
+  B & B_pdf --> C[Schema Validation (schema.yml → tests)]
+  C --> D[Delta Logic (PIN/PA new per month)]
+  D --> E[Precedence Engine (tiers, tie-break, overrides)]
+  E --> F[Exports (facts.csv, diagnostics)]
+  F --> G[Snapshots (resolver/snapshots/YYYY-MM)]
+  G --> H[API/UI (future), Analytics, Forecast Resolution]
+```
+
+## Pipeline stages
+
+- **Connector ingestion**  
+  Entry points live under `resolver/ingestion/*_client.py` and are orchestrated by [`resolver/ingestion/run_all_stubs.py`](../ingestion/run_all_stubs.py). Each connector writes a canonical CSV under `resolver/staging/`. The ReliefWeb client also drives the PDF selector when `RELIEFWEB_ENABLE_PDF=1`; see [ReliefWeb PDF](reliefweb_pdf.md).
+- **ReliefWeb PDF branch**  
+  [`resolver/ingestion/reliefweb_client.py`](../ingestion/reliefweb_client.py) hydrates report metadata, scores attachments, extracts text via [`resolver/ingestion/_pdf_text.py`](../ingestion/_pdf_text.py), and writes `resolver/staging/reliefweb_pdf.csv` plus manifest entries when the branch is enabled.
+- **Schema validation**  
+  Staging CSVs are checked against [`resolver/tools/schema.yml`](../tools/schema.yml) via [`resolver/tests/test_staging_schema_all.py`](../tests/test_staging_schema_all.py). A generated [SCHEMAS.md](../../SCHEMAS.md) provides column-level detail for exports and staging contracts.
+- **Delta preparation**  
+  Connectors output level values, but Resolver consumes monthly "new" deltas. Scripts such as [`resolver/tools/make_deltas.py`](../tools/make_deltas.py) and in-connector logic (for ReliefWeb PDFs) compute the month-over-month differences, including tier-2 ReliefWeb `series_semantics="new"` rows.
+- **Precedence engine**  
+  [`resolver/tools/precedence_engine.py`](../tools/precedence_engine.py) ranks candidates using tier policy, recency, completeness, and overrides. The logic is documented in [Precedence policy](precedence.md) and the governance appendix.
+- **Exports**  
+  [`resolver/tools/export_facts.py`](../tools/export_facts.py) consolidates staging inputs into `resolver/exports/facts.csv`, while [`resolver/tools/validate_facts.py`](../tools/validate_facts.py) enforces schema and registry rules before precedence runs.
+- **Snapshots**  
+  The freezer [`resolver/tools/freeze_snapshot.py`](../tools/freeze_snapshot.py) writes immutable monthly bundles (`resolver/snapshots/YYYY-MM`) for downstream analytics, dashboards, and the forecast resolver.
+
+## Additional references
+
+- [Connectors catalog](connectors_catalog.md)
+- [Data contracts](data_contracts.md)
+- [ReliefWeb PDF branch](reliefweb_pdf.md)
+- [Operations run book](operations.md)
+- [Troubleshooting guide](troubleshooting.md)

--- a/resolver/docs/precedence.md
+++ b/resolver/docs/precedence.md
@@ -1,0 +1,37 @@
+# Precedence Policy
+
+Resolver's precedence engine selects a single authoritative figure per `(country_iso3, hazard_code, month, metric)` by applying tier policy, recency, and deterministic tie-breakers. This page summarises the policy and illustrates how ReliefWeb PDFs integrate into tier-2 decisions.
+
+## Tier ordering
+
+The default ordering is configured in [`resolver/tools/precedence_config.yml`](../tools/precedence_config.yml) and mirrors the governance policy:
+
+1. `inter_agency_plan`
+2. `ifrc_or_gov_sitrep`
+3. `un_cluster_snapshot`
+4. `reputable_ingo_un`
+5. `media_discovery_only`
+6. `reliefweb_pdf` (tier-2 branch)
+
+ReliefWeb PDF rows are tagged with `tier=2` to ensure they are considered after tier-1 sources but before open media discovery. They are primarily used to fill gaps when higher tiers do not report monthly deltas for a given hazard month.
+
+## Tie-breaking rules
+
+When multiple rows land in the same tier:
+
+1. Prefer the row with the most recent `as_of` date.
+2. If tied, prefer the row with the most recent `publication_date`.
+3. If still tied, prefer rows with complete values (non-null `value`).
+4. Fall back to a deterministic order using the source code to avoid non-reproducible output.
+
+Manual overrides created via [`resolver/tools/precedence_engine.py --overrides`](../tools/precedence_engine.py) or review workflows supersede automated outcomes. Overrides must log a note explaining the decision.
+
+## Example scenarios
+
+- **Tier-1 present, ReliefWeb PDF present:** If IFRC GO reports a PIN value for March 2025 and a ReliefWeb PDF emits a similar metric, the engine keeps the IFRC GO figure (tier `ifrc_or_gov_sitrep`). The ReliefWeb PDF row remains visible in diagnostics for transparency.
+- **Tier-1 absent, ReliefWeb PDF fills gap:** Suppose IPC has no March 2025 update for a cyclone, but the ReliefWeb PDF pipeline produced a `people_in_need` delta. The precedence engine elevates the ReliefWeb PDF row (tier-2) so downstream exports carry a monthly new value instead of leaving a hole.
+- **Conflicting ReliefWeb PDFs:** When multiple PDFs from the same month survive the selector, the engine uses `as_of` and `publication_date` tie-breakers. Duplicates are rare because the PDF branch computes month-over-month deltas per report series before they hit precedence.
+
+## Review and auditability
+
+All precedence choices are recorded in `resolver/exports/resolved_diagnostics.csv`. ReliefWeb PDF rows surface `extraction_method`, `pph_used`, and the attachment manifest so reviewers can trace back to the source document. See [Governance & audit](governance.md) for additional controls.

--- a/resolver/docs/troubleshooting.md
+++ b/resolver/docs/troubleshooting.md
@@ -1,0 +1,30 @@
+# Troubleshooting Guide
+
+This guide captures common issues encountered when running Resolver locally or in CI, with a focus on the ReliefWeb PDF pipeline.
+
+## ReliefWeb API challenges
+
+- **HTTP 202 (WAF challenge):** ReliefWeb occasionally returns a `202 Accepted` with JavaScript challenges. The client falls back to a header-only CSV. Re-run later or supply cached manifests. The connector logs `waf_challenge_detected=1` when this occurs.
+- **Rate limits:** Respect backoff hints in `retry_after` headers; the runner automatically sleeps, but you can reduce concurrency by running `python resolver/ingestion/reliefweb_client.py --max-workers 1`.
+
+## PDF downloads
+
+- **Network disabled:** CI sets `RELIEFWEB_PDF_ALLOW_NETWORK=0`, so attachment downloads are skipped. Ensure mocks cover required fixtures before enabling the branch in tests.
+- **Invalid URLs or empty files:** The connector records failures in the manifest with `status=error`. Delete `resolver/staging/.cache/reliefweb/pdf/` to retry downloads locally.
+
+## OCR fallback
+
+- **Unexpected OCR usage:** Decrease `RELIEFWEB_PDF_ENABLE_OCR` or raise `min_text_chars_before_ocr` in the config. OCR can be slower and may require language packs not installed in minimal containers.
+- **OCR failures:** When OCR raises errors, the connector logs `extraction_method=ocr_failed` and skips the metric. Re-run with `RELIEFWEB_PDF_ENABLE_OCR=0` to avoid repeated failures.
+
+## Date and metric anomalies
+
+- **Mixed date formats:** The parser attempts multiple date patterns. Check connector logs for `date_parse_warning` messages and manually patch the PDF metadata if required.
+- **Household conversion surprises:** Inspect the `pph_used` column and confirm the value exists in `avg_household_size.csv` or overrides. Supply a custom file via `RELIEFWEB_PPH_OVERRIDE_PATH` when testing scenario-specific multipliers.
+- **Empty PDFs or images only:** Native extraction may return little text. Enable OCR for such cases, or mark the attachment as `pdf_skip=1` in the manifest to avoid repeated attempts.
+
+## General debugging tips
+
+- Inspect `resolver/logs/ingestion/*.log` for structured details (JSON) including selector scores and parsing diagnostics.
+- Use `pytest -vv` on targeted tests (e.g., `pytest -vv resolver/tests/ingestion/test_reliefweb_pdf.py::test_household_conversion`) to reproduce parsing paths quickly.
+- Confirm schema expectations with `pytest -q resolver/tests/test_staging_schema_all.py` after modifying connectors.

--- a/resolver/tests/README.md
+++ b/resolver/tests/README.md
@@ -8,6 +8,8 @@ These tests enforce basic contracts across:
 - Snapshots (`resolver/snapshots/YYYY-MM/facts.parquet`), if present
 - Remote-first state files under `resolver/state/**/exports/*.csv`
 
+Mermaid diagrams in the docs (e.g., `resolver/docs/pipeline_overview.md`) render automatically on GitHub; view them there for the most up-to-date flow visuals.
+
 ## Run locally (cross-platform)
 
 First install dev requirements:
@@ -75,3 +77,9 @@ Each connector must still produce a CSV with the canonical header (even if empty
 extraction helper so we can exercise parsing, precedence, and delta logic using
 plain strings.  No binary fixtures are required; see
 `resolver/tests/fixtures/reliefweb_pdfs/README.md` for details.
+
+### Running PDF unit tests (mocked)
+
+```bash
+pytest -q resolver/tests/ingestion/test_reliefweb_pdf.py
+```


### PR DESCRIPTION
## Summary
- add a resolver docs suite with pipeline overview, connector catalog, precedence guidance, and ReliefWeb PDF run book
- refresh the resolver README and governance page to highlight the new documentation and PDF auditing details
- extend resolver CI with a non-blocking Markdown link check for intra-repo docs

## Testing
- `python - <<'PY'
import pathlib, re
root = pathlib.Path('.').resolve()
md_files = [p for p in root.glob('resolver/**/*.md')]
pattern = re.compile(r'\[[^\]]+\]\(([^)]+)\)')
missing=[]
for md in md_files:
    text = md.read_text(encoding='utf-8')
    for match in pattern.finditer(text):
        link = match.group(1)
        if link.startswith(('http://','https://','mailto:')):
            continue
        if link.startswith('#') or link.startswith('?'):
            continue
        target = link.split('#',1)[0]
        target_path = (md.parent / target).resolve()
        if not target_path.exists():
            missing.append((md.relative_to(root), link))
if missing:
    print('Missing links:')
    for item in missing:
        print(' -', item)
else:
    print('All good')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68e3705ce4e0832cada17ac0f0eeeedd